### PR TITLE
[WIP] Issue 7 : pbs cluster init, class inheritance refactoring

### DIFF
--- a/dask_jobqueue/core.py
+++ b/dask_jobqueue/core.py
@@ -5,7 +5,7 @@ import socket
 import os
 import sys
 
-from distributed.utils import tmpfile, ignoring, get_ip_interface, parse_bytes, format_bytes
+from distributed.utils import tmpfile, ignoring, get_ip_interface, parse_bytes
 from distributed import LocalCluster
 
 dirname = os.path.dirname(sys.executable)

--- a/dask_jobqueue/core.py
+++ b/dask_jobqueue/core.py
@@ -83,6 +83,9 @@ class JobQueueCluster(object):
         if not self.cancel_command or not self.submit_command:
             raise NotImplementedError('JobQueueCluster is an abstract class that should not be instanciated.')
 
+        #This attribute should be overriden
+        self.job_header = None
+
         if interface:
             host = get_ip_interface(interface)
             extra += ' --interface  %s ' % interface
@@ -96,7 +99,7 @@ class JobQueueCluster(object):
         self._adaptive = None
 
         #dask-worker command line build
-        self._command_template = "%s/dask-worker %s" % (dirname, self.scheduler.address)
+        self._command_template = os.path.join(dirname, 'dask-worker %s' % self.scheduler.address)
         if threads is not None:
             self._command_template += " --nthreads %d" % threads
         if processes is not None:
@@ -118,17 +121,6 @@ class JobQueueCluster(object):
         return self._script_template % {'job_header': self.job_header,
                                         'worker_command': self._command_template % {'n': self.n}
                                         }
-
-    @property
-    def job_header(self):
-        """
-        Abstract attribute for the Job scheduler script header part.
-
-        Returns
-        -------
-        A string containing multiple lines to be used as header of job file to be sumitted.
-        """
-        raise NotImplementedError
 
     @contextmanager
     def job_file(self):

--- a/dask_jobqueue/core.py
+++ b/dask_jobqueue/core.py
@@ -4,6 +4,7 @@ import subprocess
 import socket
 import os
 import sys
+import docrep
 
 from distributed.utils import tmpfile, ignoring, get_ip_interface, parse_bytes
 from distributed import LocalCluster
@@ -11,8 +12,10 @@ from distributed import LocalCluster
 dirname = os.path.dirname(sys.executable)
 
 logger = logging.getLogger(__name__)
+docstrings = docrep.DocstringProcessor()
 
 
+@docstrings.get_sectionsf('JobQueueCluster')
 class JobQueueCluster(object):
     """ Base class to launch Dask Clusters for Job queues
 

--- a/dask_jobqueue/core.py
+++ b/dask_jobqueue/core.py
@@ -5,7 +5,7 @@ import socket
 import os
 import sys
 
-from distributed.utils import tmpfile, ignoring, get_ip_interface
+from distributed.utils import tmpfile, ignoring, get_ip_interface, parse_bytes, format_bytes
 from distributed import LocalCluster
 
 dirname = os.path.dirname(sys.executable)
@@ -93,6 +93,11 @@ class JobQueueCluster(object):
             host = socket.gethostname()
 
         self.cluster = LocalCluster(n_workers=0, ip=host, **kwargs)
+
+        #Keep information on process, threads and memory, for use in subclasses
+        self.worker_memory = parse_bytes(memory)
+        self.worker_processes = processes
+        self.worker_threads = threads
 
         self.jobs = dict()
         self.n = 0

--- a/dask_jobqueue/pbs.py
+++ b/dask_jobqueue/pbs.py
@@ -24,7 +24,7 @@ class PBSCluster(JobQueueCluster):
     walltime : str
         Walltime for each worker job.
     job_extra : list
-        List of other PBS options, for example -j oe. Passed with '#PBS ' prefix
+        List of other PBS options, for example -j oe. Each option will be prepended with the #PBS prefix.
     local_directory : str
         Dask worker local directory for file spilling.
     kwargs : dict
@@ -51,7 +51,7 @@ class PBSCluster(JobQueueCluster):
     Examples
     --------
     >>> from dask_jobqueue import PBSCluster
-    >>> cluster = PBSCluster(queue= 'regular', project='DaskOnPBS')
+    >>> cluster = PBSCluster(queue='regular', project='DaskOnPBS')
     >>> cluster.start_workers(10)  # this may take a few seconds to launch
 
     >>> from dask.distributed import Client
@@ -74,11 +74,10 @@ class PBSCluster(JobQueueCluster):
                  resource_spec='select=1:ncpus=24:mem=100GB',
                  walltime='00:30:00',
                  job_extra=[],
-                 local_directory='$TMPDIR',
                  **kwargs):
 
         #Instantiate args and parameters from parent abstract class
-        super(PBSCluster, self).__init__(name=name, local_directory=local_directory, **kwargs)
+        super(PBSCluster, self).__init__(name=name, **kwargs)
 
         #Try to find a project name from environment variable
         project = project or os.environ.get('PBS_ACCOUNT')
@@ -95,10 +94,7 @@ class PBSCluster(JobQueueCluster):
             header_lines.append('#PBS -l walltime=%s' % walltime)
         header_lines.extend(['#PBS %s' % arg for arg in job_extra])
 
-        self._job_header = '\n'.join(header_lines)
+        #Declare class attribute that shall be overriden
+        self.job_header = '\n'.join(header_lines)
 
         logger.debug("Job script: \n %s" % self.job_script())
-
-    @property
-    def job_header(self):
-        return self._job_header

--- a/dask_jobqueue/pbs.py
+++ b/dask_jobqueue/pbs.py
@@ -3,7 +3,6 @@ import os
 import math
 
 from .core import JobQueueCluster
-from distributed.utils import format_bytes
 
 logger = logging.getLogger(__name__)
 
@@ -116,6 +115,7 @@ class PBSCluster(JobQueueCluster):
 
         logger.debug("Job script: \n %s" % self.job_script())
 
+
 def pbs_format_bytes_ceil(n):
     """ Format bytes as text
     PBS expects KiB, MiB or Gib, but names it KB, MB, GB
@@ -132,10 +132,10 @@ def pbs_format_bytes_ceil(n):
     >>> pbs_format_bytes_ceil(15000000000)
     '14GB'
     """
-    if n >= 10*(1024**3):
+    if n >= 10 * (1024**3):
         return '%dGB' % math.ceil(n / (1024**3))
-    if n >= 10*(1024**2):
+    if n >= 10 * (1024**2):
         return '%dMB' % (n / (1024**2))
-    if n >= 10*1024:
+    if n >= 10 * 1024:
         return '%dkB' % (n / 1024)
     return '%dB' % n

--- a/dask_jobqueue/pbs.py
+++ b/dask_jobqueue/pbs.py
@@ -9,6 +9,7 @@ logger = logging.getLogger(__name__)
 class PBSCluster(JobQueueCluster):
     """ Launch Dask on a PBS cluster
 
+
     Parameters
     ----------
     name : str
@@ -61,6 +62,11 @@ class PBSCluster(JobQueueCluster):
     kill workers based on load.
 
     >>> cluster.adapt()
+
+    It is a good practice to define local_directory to your PBS system scratch directory,
+    and you should specify resource_spec according to the processes and threads asked:
+    >>> cluster = PBSCluster(queue='regular', project='DaskOnPBS',local_directory=os.getenv('TMPDIR', '/tmp'), \
+                             threads=4, processes=6, memory='16GB', resource_spec='select=1:ncpus=24:mem=100GB')
     """
 
     #Override class variables

--- a/dask_jobqueue/pbs.py
+++ b/dask_jobqueue/pbs.py
@@ -2,19 +2,17 @@ import logging
 import os
 import math
 
-from .core import JobQueueCluster
+from .core import JobQueueCluster, docstrings
 
 logger = logging.getLogger(__name__)
 
 
+@docstrings.with_indent(4)
 class PBSCluster(JobQueueCluster):
     """ Launch Dask on a PBS cluster
 
-
     Parameters
     ----------
-    name : str
-        Name of worker jobs and Dask workers. Passed to `$PBS -N` option.
     queue : str
         Destination queue for each worker job. Passed to `#PBS -q` option.
     project : str
@@ -29,30 +27,7 @@ class PBSCluster(JobQueueCluster):
         List of other PBS options, for example -j oe. Each option will be prepended with the #PBS prefix.
     local_directory : str
         Dask worker local directory for file spilling.
-    kwargs : dict
-        Additional keyword arguments to pass to `JobQueueCluster` and `LocalCluster`
-
-    Inherited parameters from JobQueueCluster
-    -----------------------------------------
-    name : str
-        Name of Dask workers.
-    threads : int
-        Number of threads per process.
-    processes : int
-        Number of processes per node.
-    memory : str
-        Bytes of memory that the worker can use. This should be a string
-        like "7GB" that can be interpretted both by PBS and Dask.
-    interface : str
-        Network interface like 'eth0' or 'ib0'.
-    death_timeout : float
-        Seconds to wait for a scheduler before closing workers
-    local_directory : str
-        Dask worker local directory for file spilling.
-    extra : str
-        Additional arguments to pass to `dask-worker`
-    kwargs : dict
-        Additional keyword arguments to pass to `LocalCluster`
+    %(JobQueueCluster.parameters)s
 
     Examples
     --------
@@ -79,7 +54,6 @@ class PBSCluster(JobQueueCluster):
     cancel_command = 'qdel'
 
     def __init__(self,
-                 name='dask-worker',
                  queue=None,
                  project=None,
                  resource_spec=None,
@@ -88,13 +62,14 @@ class PBSCluster(JobQueueCluster):
                  **kwargs):
 
         #Instantiate args and parameters from parent abstract class
-        super(PBSCluster, self).__init__(name=name, **kwargs)
+        super(PBSCluster, self).__init__(**kwargs)
 
         #Try to find a project name from environment variable
         project = project or os.environ.get('PBS_ACCOUNT')
 
         #PBS header build
-        header_lines = ['#PBS -N %s' % name]
+        if self.name is not None:
+            header_lines = ['#PBS -N %s' % self.name]
         if queue is not None:
             header_lines.append('#PBS -q %s' % queue)
         if project is not None:

--- a/dask_jobqueue/pbs.py
+++ b/dask_jobqueue/pbs.py
@@ -1,15 +1,9 @@
 import logging
 import os
-import sys
-
-from distributed import LocalCluster
-from distributed.utils import get_ip_interface
 
 from .core import JobQueueCluster
 
 logger = logging.getLogger(__name__)
-
-dirname = os.path.dirname(sys.executable)
 
 
 class PBSCluster(JobQueueCluster):
@@ -17,32 +11,39 @@ class PBSCluster(JobQueueCluster):
 
     Parameters
     ----------
-    job_name : str
-        Name of worker jobs. Passed to `$PBS -N` option.
+    name : str
+        Name of worker jobs and Dask workers. Passed to `$PBS -N` option.
     queue : str
         Destination queue for each worker job. Passed to `#PBS -q` option.
     project : str
         Accounting string associated with each worker job. Passed to
         `#PBS -A` option.
-    threads_per_worker : int
+    resource_spec : str
+        Request resources and specify job placement. Passed to `#PBS -l`
+        option.
+    walltime : str
+        Walltime for each worker job.
+    job_extra : list
+        List of other PBS options, for example -j oe. Passed with '#PBS ' prefix
+    local_directory : str
+        Dask worker local directory for file spilling.
+    kwargs : dict
+        Additional keyword arguments to pass to `JobQueueCluster` and `LocalCluster`
+
+    Inherited parameters
+    --------------------
+    threads : int
         Number of threads per process.
     processes : int
         Number of processes per node.
     memory : str
         Bytes of memory that the worker can use. This should be a string
         like "7GB" that can be interpretted both by PBS and Dask.
-    resource_spec : str
-        Request resources and specify job placement. Passed to `#PBS -l`
-        option.
-    walltime : str
-        Walltime for each worker job.
     interface : str
         Network interface like 'eth0' or 'ib0'.
     death_timeout : float
         Seconds to wait for a scheduler before closing workers
-    job_extra : list
-        Additional lines to put in PBS script header (usually starting with #PBS comment)
-    worker_extra : str
+    extra : str
         Additional arguments to pass to `dask-worker`
     kwargs : dict
         Additional keyword arguments to pass to `LocalCluster`
@@ -61,59 +62,44 @@ class PBSCluster(JobQueueCluster):
 
     >>> cluster.adapt()
     """
+
+    _submitcmd = 'qsub'
+    _cancelcmd = 'qdel'
+
+
     def __init__(self,
                  name='dask-worker',
                  queue=None,
                  project=None,
-                 resource_spec='select=1:ncpus=24:mem=120GB',
+                 resource_spec='select=1:ncpus=24:mem=100GB',
                  walltime='00:30:00',
-                 pbs_extra=[],
-                 threads_per_worker=4,
-                 processes=6,
-                 memory='20GB',
-                 interface=None,
-                 death_timeout=60,
-                 worker_extra='',
+                 job_extra=[],
+                 local_directory='$TMPDIR',
                  **kwargs):
-        self._template = """
-#!/bin/bash
 
-#PBS -N %(name)s
-#PBS -q %(queue)s
-#PBS -A %(project)s
-#PBS -l %(resource_spec)s
-#PBS -l walltime=%(walltime)s
-#PBS -j oe
-
-%(base_path)s/dask-worker %(scheduler)s \
-    --nthreads %(threads_per_worker)d \
-    --nprocs %(processes)s \
-    --memory-limit %(memory)s \
-    --name %(name)s-%(n)d \
-    --death-timeout %(death_timeout)s \
-     %(extra)s
-""".lstrip()
+        super(PBSCluster, self).__init__(name=name, local_directory=local_directory, **kwargs)
 
         project = project or os.environ.get('PBS_ACCOUNT')
 
-        super(PBSCluster, self).__init__(threads_per_worker=threads_per_worker,processes=processes,
-                 memory=memory,interface=interface,death_timeout=death_timeout,worker_extra=worker_extra,
-                 **kwargs)
+        header_lines = ['#PBS -N %s' % name]
+        if queue != None: header_lines.append('#PBS -q %s' % queue)
+        if project != None: header_lines.append('#PBS -A %s' % project)
+        if resource_spec != None: header_lines.append('#PBS -l %s' % resource_spec)
+        if walltime != None: header_lines.append('#PBS -l walltime=%s' % walltime)
+        header_lines.extend(['#PBS %s' % arg for arg in job_extra])
 
-        self.config = {'name': name,
-                       'queue': queue,
-                       'project': project,
-                       'threads_per_worker': threads_per_worker,
-                       'processes': processes,
-                       'walltime': walltime,
-                       'scheduler': self.scheduler.address,
-                       'resource_spec': resource_spec,
-                       'base_path': dirname,
-                       'memory': memory,
-                       'death_timeout': death_timeout,
-                       'extra': worker_extra}
-
-        self._submitcmd = 'qsub'
-        self._cancelcmd = 'qdel'
+        self._job_header = '\n'.join(header_lines)
 
         logger.debug("Job script: \n %s" % self.job_script())
+
+    @property
+    def job_header(self):
+        return self._job_header
+
+    @property
+    def submitcmd(self):
+        return self._submitcmd
+
+    @property
+    def cancelcmd(self):
+        return self._cancelcmd

--- a/dask_jobqueue/pbs.py
+++ b/dask_jobqueue/pbs.py
@@ -33,8 +33,10 @@ class PBSCluster(JobQueueCluster):
     kwargs : dict
         Additional keyword arguments to pass to `JobQueueCluster` and `LocalCluster`
 
-    Inherited parameters
-    --------------------
+    Inherited parameters from JobQueueCluster
+    -----------------------------------------
+    name : str
+        Name of Dask workers.
     threads : int
         Number of threads per process.
     processes : int
@@ -46,6 +48,8 @@ class PBSCluster(JobQueueCluster):
         Network interface like 'eth0' or 'ib0'.
     death_timeout : float
         Seconds to wait for a scheduler before closing workers
+    local_directory : str
+        Dask worker local directory for file spilling.
     extra : str
         Additional arguments to pass to `dask-worker`
     kwargs : dict

--- a/dask_jobqueue/slurm.py
+++ b/dask_jobqueue/slurm.py
@@ -113,4 +113,3 @@ export LC_ALL="en_US.utf8"
         self.job_header = self._header_template % self.config
 
         logger.debug("Job script: \n %s" % self.job_script())
-

--- a/dask_jobqueue/slurm.py
+++ b/dask_jobqueue/slurm.py
@@ -60,7 +60,7 @@ class SLURMCluster(JobQueueCluster):
             Walltime for each worker job.
         kwargs : dict
             Additional keyword arguments to pass to `JobQueueCluster` and `LocalCluster`
-            
+
         Inherited parameters from JobQueueCluster
         -----------------------------------------
         name : str
@@ -86,7 +86,6 @@ class SLURMCluster(JobQueueCluster):
 
         super(SLURMCluster, self).__init__(name=name, processes=processes, **kwargs)
 
-        #Keeping template for now has I don't know much about slurm.
         self._header_template = """
 #SBATCH -J %(name)s
 #SBATCH -n %(processes)d

--- a/dask_jobqueue/slurm.py
+++ b/dask_jobqueue/slurm.py
@@ -27,8 +27,9 @@ class SLURMCluster(JobQueueCluster):
     >>> cluster.adapt()
     """
 
-    _submitcmd = 'sbatch'
-    _cancelcmd = 'scancel'
+    #Override class variables
+    submit_command = 'sbatch'
+    cancel_command = 'scancel'
 
     def __init__(self,
                  name='dask',
@@ -98,11 +99,3 @@ export LC_ALL="en_US.utf8"
     @property
     def job_header(self):
         return self._job_header
-
-    @property
-    def submitcmd(self):
-        return self._submitcmd
-
-    @property
-    def cancelcmd(self):
-        return self._cancelcmd

--- a/dask_jobqueue/slurm.py
+++ b/dask_jobqueue/slurm.py
@@ -60,12 +60,31 @@ class SLURMCluster(JobQueueCluster):
             Walltime for each worker job.
         kwargs : dict
             Additional keyword arguments to pass to `JobQueueCluster` and `LocalCluster`
+            
+        Inherited parameters from JobQueueCluster
+        -----------------------------------------
+        name : str
+            Name of Dask workers.
+        threads : int
+            Number of threads per process.
+        processes : int
+            Number of processes per node.
+        memory : str
+            Bytes of memory that the worker can use. This should be a string
+            like "7GB" that can be interpretted both by PBS and Dask.
+        interface : str
+            Network interface like 'eth0' or 'ib0'.
+        death_timeout : float
+            Seconds to wait for a scheduler before closing workers
+        local_directory : str
+            Dask worker local directory for file spilling.
+        extra : str
+            Additional arguments to pass to `dask-worker`
+        kwargs : dict
+        Additional keyword arguments to pass to `LocalCluster`
         """
 
         super(SLURMCluster, self).__init__(name=name, processes=processes, **kwargs)
-
-        #TODO has this been tested? This seems weird to use only processes, and not processes * threads
-        # There are no memory limit given to Slurm either?
 
         #Keeping template for now has I don't know much about slurm.
         self._header_template = """

--- a/dask_jobqueue/slurm.py
+++ b/dask_jobqueue/slurm.py
@@ -92,10 +92,7 @@ export LC_ALL="en_US.utf8"
                        'memory': memory
                        }
 
-        self._job_header = self._header_template % self.config
+        self.job_header = self._header_template % self.config
 
         logger.debug("Job script: \n %s" % self.job_script())
 
-    @property
-    def job_header(self):
-        return self._job_header

--- a/dask_jobqueue/slurm.py
+++ b/dask_jobqueue/slurm.py
@@ -2,13 +2,14 @@ import logging
 import os
 import sys
 
-from .core import JobQueueCluster
+from .core import JobQueueCluster, docstrings
 
 logger = logging.getLogger(__name__)
 
 dirname = os.path.dirname(sys.executable)
 
 
+@docstrings.with_indent(4)
 class SLURMCluster(JobQueueCluster):
     """ Launch Dask on a SLURM cluster
 
@@ -32,7 +33,6 @@ class SLURMCluster(JobQueueCluster):
     cancel_command = 'scancel'
 
     def __init__(self,
-                 name='dask',
                  queue='',
                  project=None,
                  processes=8,
@@ -43,8 +43,6 @@ class SLURMCluster(JobQueueCluster):
 
         Parameters
         ----------
-        name : str
-            Name of worker jobs. Passed to `#SBATCH -J` option.
         queue : str
             Destination queue for each worker job.
             Passed to `#SBATCH -p` option.
@@ -58,33 +56,10 @@ class SLURMCluster(JobQueueCluster):
             like "7GB" that can be interpretted both by PBS and Dask.
         walltime : str
             Walltime for each worker job.
-        kwargs : dict
-            Additional keyword arguments to pass to `JobQueueCluster` and `LocalCluster`
-
-        Inherited parameters from JobQueueCluster
-        -----------------------------------------
-        name : str
-            Name of Dask workers.
-        threads : int
-            Number of threads per process.
-        processes : int
-            Number of processes per node.
-        memory : str
-            Bytes of memory that the worker can use. This should be a string
-            like "7GB" that can be interpretted both by PBS and Dask.
-        interface : str
-            Network interface like 'eth0' or 'ib0'.
-        death_timeout : float
-            Seconds to wait for a scheduler before closing workers
-        local_directory : str
-            Dask worker local directory for file spilling.
-        extra : str
-            Additional arguments to pass to `dask-worker`
-        kwargs : dict
-        Additional keyword arguments to pass to `LocalCluster`
+        %(JobQueueCluster.parameters)s
         """
 
-        super(SLURMCluster, self).__init__(name=name, processes=processes, **kwargs)
+        super(SLURMCluster, self).__init__(processes=processes, **kwargs)
 
         self._header_template = """
 #SBATCH -J %(name)s
@@ -101,7 +76,7 @@ export LC_ALL="en_US.utf8"
 """.lstrip()
 
         memory = memory.replace(' ', '')
-        self.config = {'name': name,
+        self.config = {'name': self.name,
                        'queue': queue,
                        'project': project,
                        'processes': processes,

--- a/dask_jobqueue/slurm.py
+++ b/dask_jobqueue/slurm.py
@@ -1,10 +1,6 @@
 import logging
 import os
-import socket
 import sys
-
-from distributed import LocalCluster
-from distributed.utils import get_ip_interface
 
 from .core import JobQueueCluster
 
@@ -30,17 +26,17 @@ class SLURMCluster(JobQueueCluster):
 
     >>> cluster.adapt()
     """
+
+    _submitcmd = 'sbatch'
+    _cancelcmd = 'scancel'
+
     def __init__(self,
                  name='dask',
                  queue='',
                  project=None,
-                 threads_per_worker=4,
                  processes=8,
                  memory='7GB',
                  walltime='00:30:00',
-                 interface=None,
-                 death_timeout=60,
-                 extra='',
                  **kwargs):
         """ Initialize a SLURM Cluster
 
@@ -54,8 +50,6 @@ class SLURMCluster(JobQueueCluster):
         project : str
             Accounting string associated with each worker job. Passed to
             `#SBATCH -A` option.
-        threads_per_worker : int
-            Number of threads per process.
         processes : int
             Number of processes per node.
         memory : str
@@ -63,18 +57,17 @@ class SLURMCluster(JobQueueCluster):
             like "7GB" that can be interpretted both by PBS and Dask.
         walltime : str
             Walltime for each worker job.
-        interface : str
-            Network interface like 'eth0' or 'ib0'.
-        death_timeout : float
-            Seconds to wait for a scheduler before closing workers
-        extra : str
-            Additional arguments to pass to `dask-worker`
         kwargs : dict
-            Additional keyword arguments to pass to `LocalCluster`
+            Additional keyword arguments to pass to `JobQueueCluster` and `LocalCluster`
         """
-        self._template = """
-#!/bin/bash
 
+        super(SLURMCluster, self).__init__(name=name, processes=processes, **kwargs)
+
+        #TODO has this been tested? This seems weird to use only processes, and not processes * threads
+        # There are no memory limit given to Slurm either?
+
+        #Keeping template for now has I don't know much about slurm.
+        self._header_template = """
 #SBATCH -J %(name)s
 #SBATCH -n %(processes)d
 #SBATCH -p %(queue)s
@@ -86,43 +79,30 @@ class SLURMCluster(JobQueueCluster):
 export LANG="en_US.utf8"
 export LANGUAGE="en_US.utf8"
 export LC_ALL="en_US.utf8"
-
-%(base_path)s/dask-worker %(scheduler)s \
-    --nthreads %(threads_per_worker)d \
-    --nprocs %(processes)s \
-    --memory-limit %(memory)s \
-    --name %(name)s-%(n)d \
-    --death-timeout %(death_timeout)s \
-     %(extra)s
 """.lstrip()
 
-        if interface:
-            host = get_ip_interface(interface)
-            extra += ' --interface  %s ' % interface
-        else:
-            host = socket.gethostname()
-
-        project = project or os.environ.get('SLURM_ACCOUNT')
-        if not project:
-            raise ValueError("Must specify a project like `project='UCLB1234' "
-                             "or set SLURM_ACCOUNT environment variable")
-        self.cluster = LocalCluster(n_workers=0, ip=host, **kwargs)
         memory = memory.replace(' ', '')
         self.config = {'name': name,
                        'queue': queue,
                        'project': project,
-                       'threads_per_worker': threads_per_worker,
                        'processes': processes,
-                       'scheduler': self.scheduler.address,
                        'walltime': walltime,
-                       'base_path': dirname,
-                       'memory': memory,
-                       'death_timeout': death_timeout,
-                       'extra': extra}
-        self.jobs = dict()
-        self.n = 0
-        self._adaptive = None
-        self._submitcmd = 'sbatch'
-        self._cancelcmd = 'scancel'
+                       # Not used
+                       'memory': memory
+                       }
+
+        self._job_header = self._header_template % self.config
 
         logger.debug("Job script: \n %s" % self.job_script())
+
+    @property
+    def job_header(self):
+        return self._job_header
+
+    @property
+    def submitcmd(self):
+        return self._submitcmd
+
+    @property
+    def cancelcmd(self):
+        return self._cancelcmd

--- a/dask_jobqueue/tests/test_pbs.py
+++ b/dask_jobqueue/tests/test_pbs.py
@@ -5,11 +5,11 @@ import pytest
 
 from dask.distributed import Client
 from distributed.utils_test import loop  # noqa: F401
-from pangeo import PBSCluster
+from dask_jobqueue import PBSCluster
 
 
 def test_basic(loop):
-    with PBSCluster(walltime='00:02:00', threads_per_worker=2, memory='7GB',
+    with PBSCluster(walltime='00:02:00', threads=2, memory='7GB',
                     interface='ib0', loop=loop) as cluster:
         with Client(cluster) as client:
             workers = cluster.start_workers(2)

--- a/dask_jobqueue/tests/test_slurm.py
+++ b/dask_jobqueue/tests/test_slurm.py
@@ -5,12 +5,12 @@ import pytest
 
 from dask.distributed import Client
 from distributed.utils_test import loop  # noqa: F401
-from pangeo import SLURMCluster
+from dask_jobqueue import SLURMCluster
 
 
 def test_basic(loop):
-    with SLURMCluster(walltime='00:02:00', threads_per_worker=2, memory='7GB',
-                    loop=loop) as cluster:
+    with SLURMCluster(walltime='00:02:00', threads=2, memory='7GB',
+                      loop=loop) as cluster:
         with Client(cluster) as client:
             workers = cluster.start_workers(2)
             future = client.submit(lambda x: x + 1, 10)
@@ -42,8 +42,7 @@ def test_adaptive(loop):
             assert cluster.jobs
 
             start = time()
-            while len(client.scheduler_info()['workers']) \
-                  != cluster.config['processes']:
+            while len(client.scheduler_info()['workers']) != cluster.config['processes']:
                 sleep(0.1)
                 assert time() < start + 10
 

--- a/setup.py
+++ b/setup.py
@@ -10,4 +10,5 @@ setup(name='dask-jobqueue',
       license='BSD 3-Clause',
       packages=['dask_jobqueue'],
       long_description=(open('README.rst').read() if exists('README.rst') else ''),
+      install_requires=['docrep'],
       zip_safe=False)


### PR DESCRIPTION
So looking for comment here as this is my first pull request ever. 

I've made some significant changes from the master branch:
* As issue #7 first mentioned, I've remove the check on project being defined or not,
* I've made the PBS header construction, but also the dask-worker command construction more flexible, as suggested by @jhamman,
* I've moved some logic from PBS/SLURM classes to the JobQueueCluster parent class. It follows an abstract class pattern, but I've decided not to use ABC Metaclass for the sake of simplicity and python 2.7 easier compatibility as discussed with @mrocklin. So I've juste defined some abstract method by raising NotImplementedError in the JobQueueCluster class.

A question too on SLURMCluster. I've modified its implementation, but I've left the fixed header template logic here, as I am not a SLURM user. Anyway I still have some questioning about the CPU and memory resources in this class : we use only the processes (so nprocs) of dask here, but I would expect to see something like processes * nthreads; moreover, I don't see any memory limit in the template.

Finaly, I've not yet tested this in real condition, only some basic play with job script construction into a python terminal (and by the way I believe we should add some basic unit tests like that, don't you think?).