### PR TITLE
No queue arguments needed on SLURM for most clusters.

### DIFF
--- a/dask_jobqueue/core.py
+++ b/dask_jobqueue/core.py
@@ -4,9 +4,7 @@ import subprocess
 import toolz
 
 from distributed.utils import tmpfile, ignoring
-
 logger = logging.getLogger(__name__)
-
 
 class JobQueueCluster(object):
     """ Base class to launch Dask Clusters for Job queues
@@ -75,6 +73,7 @@ class JobQueueCluster(object):
         Also logs any stderr information
         """
         logger.debug("Submitting the following calls to command line")
+        
         for cmd in cmds:
             logger.debug(' '.join(cmd))
         procs = [subprocess.Popen(cmd,

--- a/dask_jobqueue/slurm.py
+++ b/dask_jobqueue/slurm.py
@@ -48,12 +48,9 @@ class SLURMCluster(JobQueueCluster):
         ----------
         name : str
             Name of worker jobs. Passed to `#SBATCH -J` option.
-        queue : str
-            Destination queue for each worker job.
-            Passed to `#SBATCH -p` option.
         project : str
             Accounting string associated with each worker job. Passed to
-            `#SBATCH --account` option.
+            `#SBATCH -A` option.
         threads_per_worker : int
             Number of threads per process.
         processes : int
@@ -77,8 +74,7 @@ class SLURMCluster(JobQueueCluster):
 
 #SBATCH -J %(name)s
 #SBATCH -n %(processes)d
-#SBATCH -p %(queue)s
-#SBATCH --account %(project)s
+#SBATCH -A %(project)s
 #SBATCH -t %(walltime)s
 #SBATCH -e %(name)s.err
 #SBATCH -o %(name)s.out
@@ -87,7 +83,7 @@ export LANG="en_US.utf8"
 export LANGUAGE="en_US.utf8"
 export LC_ALL="en_US.utf8"
 
-%(base_path)s/dask-worker %(scheduler)s \
+"%(base_path)s/dask-worker" %(scheduler)s \
     --nthreads %(threads_per_worker)d \
     --nprocs %(processes)s \
     --memory-limit %(memory)s \

--- a/dask_jobqueue/slurm.py
+++ b/dask_jobqueue/slurm.py
@@ -53,7 +53,7 @@ class SLURMCluster(JobQueueCluster):
             Passed to `#SBATCH -p` option.
         project : str
             Accounting string associated with each worker job. Passed to
-            `#SBATCH -A` option.
+            `#SBATCH --account` option.
         threads_per_worker : int
             Number of threads per process.
         processes : int
@@ -78,7 +78,7 @@ class SLURMCluster(JobQueueCluster):
 #SBATCH -J %(name)s
 #SBATCH -n %(processes)d
 #SBATCH -p %(queue)s
-#SBATCH -A %(project)s
+#SBATCH --account %(project)s
 #SBATCH -t %(walltime)s
 #SBATCH -e %(name)s.err
 #SBATCH -o %(name)s.out

--- a/dask_jobqueue/slurm.py
+++ b/dask_jobqueue/slurm.py
@@ -32,7 +32,6 @@ class SLURMCluster(JobQueueCluster):
     """
     def __init__(self,
                  name='dask',
-                 queue='',
                  project=None,
                  threads_per_worker=4,
                  processes=8,
@@ -105,7 +104,6 @@ export LC_ALL="en_US.utf8"
         self.cluster = LocalCluster(n_workers=0, ip=host, **kwargs)
         memory = memory.replace(' ', '')
         self.config = {'name': name,
-                       'queue': queue,
                        'project': project,
                        'threads_per_worker': threads_per_worker,
                        'processes': processes,


### PR DESCRIPTION
Removed queue from default arguments. The default was empty, which caused the following arguments to be poorly parsed by SLURM. The university clusters I have worked with do not use the -p flag. Of course, it may vary by cluster. This reverts #18, which probably wasn't needed. 

Closes #15 