### PR TITLE
Basic unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ log
 *.swp
 *.swo
 .cache/
+.pytest_cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,10 @@ matrix:
       env:
         - OS=ubuntu-14.04
         - JOBQUEUE=sge
+    - python: "3.6"
+      env:
+        - OS=ubuntu-14.04
+        - JOBQUEUE=basic
 env:
   global:
     - DOCKER_COMPOSE_VERSION=1.6.0

--- a/ci/basic.sh
+++ b/ci/basic.sh
@@ -7,8 +7,8 @@ function jobqueue_before_install {
     docker-compose version
 
     # just build and start a container with python dependencies
-    docker build -t dask-jobqueue:latest basic/
-    docker run -d --name test_server -v `pwd`../..:/dask-jobqueue dask-jobqueue:latest sleep 600
+    docker build -t dask-jobqueue:latest ci/basic/
+    docker run -d --name test_server -v `pwd`:/dask-jobqueue dask-jobqueue:latest sleep 600
 
     docker ps -a
     docker images

--- a/ci/basic.sh
+++ b/ci/basic.sh
@@ -23,5 +23,5 @@ function jobqueue_script {
 }
 
 function jobqueue_after_success {
-
+    echo "Hurrah"
 }

--- a/ci/basic.sh
+++ b/ci/basic.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+set -x
+
+function jobqueue_before_install {
+    docker version
+    docker-compose version
+
+    # start a container
+    docker build -t dask-jobqueue:latest basic/
+    docker run -d --name test_server -v `pwd`../..:/dask-jobqueue dask-jobqueue:latest sleep 600
+
+    docker ps -a
+    docker images
+}
+
+function jobqueue_install {
+    docker exec -it test_server /bin/bash -c "cd /dask-jobqueue; python setup.py install"
+}
+
+function jobqueue_script {
+    docker exec -it test_server /bin/bash -c "cd /dask-jobqueue; py.test dask_jobqueue --verbose"
+}
+
+function jobqueue_after_success {
+
+}

--- a/ci/basic.sh
+++ b/ci/basic.sh
@@ -6,7 +6,7 @@ function jobqueue_before_install {
     docker version
     docker-compose version
 
-    # start a container
+    # just build and start a container with python dependencies
     docker build -t dask-jobqueue:latest basic/
     docker run -d --name test_server -v `pwd`../..:/dask-jobqueue dask-jobqueue:latest sleep 600
 

--- a/ci/basic/Dockerfile
+++ b/ci/basic/Dockerfile
@@ -1,0 +1,14 @@
+FROM ubuntu:14.04
+
+ENV LANG C.UTF-8
+
+RUN apt-get update && apt-get install curl bzip2 git gcc -y --fix-missing
+
+RUN curl -o miniconda.sh https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh && \
+    bash miniconda.sh -f -b -p /opt/anaconda && \
+    /opt/anaconda/bin/conda clean -tipy && \
+    rm -f miniconda.sh
+ENV PATH /opt/anaconda/bin:$PATH
+RUN conda install -n root conda=4.4.11 && conda clean -tipy
+RUN conda install -c conda-forge dask distributed blas pytest mock ipython pip psutil && conda clean -tipy
+

--- a/dask_jobqueue/tests/test_jobqueue_core.py
+++ b/dask_jobqueue/tests/test_jobqueue_core.py
@@ -1,4 +1,15 @@
+import pytest
+
+from dask_jobqueue import JobQueueCluster
+
 
 def test_jq_core_placeholder():
     # to test that CI is working
     pass
+
+
+def test_errors():
+    with pytest.raises(NotImplementedError) as info:
+        JobQueueCluster()
+
+    assert 'abstract class' in str(info.value)

--- a/dask_jobqueue/tests/test_pbs.py
+++ b/dask_jobqueue/tests/test_pbs.py
@@ -7,6 +7,7 @@ from dask.distributed import Client
 from distributed.utils_test import loop  # noqa: F401
 from dask_jobqueue import PBSCluster
 
+#Run test only if py.test -E pbs is called
 pytestmark = pytest.mark.env("pbs")
 
 

--- a/dask_jobqueue/tests/test_pbs_basic.py
+++ b/dask_jobqueue/tests/test_pbs_basic.py
@@ -1,0 +1,71 @@
+from dask_jobqueue import PBSCluster
+
+#No mark in order to run these simple unit tests all the time
+
+
+def test_header():
+    with PBSCluster(walltime='00:02:00', processes=4, threads=2, memory='7GB') as cluster:
+
+        assert '#PBS' in cluster.job_header
+        assert '#PBS -N dask-worker' in cluster.job_header
+        assert '#PBS -l select=1:ncpus=8:mem=27GB' in cluster.job_header
+        assert '#PBS -l walltime=00:02:00' in cluster.job_header
+        assert '#PBS -q' not in cluster.job_header
+        assert '#PBS -A' not in cluster.job_header
+
+    with PBSCluster(queue='regular', project='DaskOnPBS', processes=4, threads=2, memory='7GB',
+                    resource_spec='select=1:ncpus=24:mem=100GB') as cluster:
+
+        assert '#PBS -q regular' in cluster.job_header
+        assert '#PBS -N dask-worker' in cluster.job_header
+        assert '#PBS -l select=1:ncpus=24:mem=100GB' in cluster.job_header
+        assert '#PBS -l select=1:ncpus=8:mem=27GB' not in cluster.job_header
+        assert '#PBS -l walltime=' in cluster.job_header
+        assert '#PBS -A DaskOnPBS' in cluster.job_header
+
+    with PBSCluster() as cluster:
+
+        assert '#PBS -j oe' not in cluster.job_header
+        assert '#PBS -N' in cluster.job_header
+        assert '#PBS -l select=1:ncpus=' in cluster.job_header
+        assert '#PBS -l walltime=' in cluster.job_header
+        assert '#PBS -A' not in cluster.job_header
+        assert '#PBS -q' not in cluster.job_header
+
+    with PBSCluster(job_extra=['-j oe']) as cluster:
+
+        assert '#PBS -j oe' in cluster.job_header
+        assert '#PBS -N' in cluster.job_header
+        assert '#PBS -l select=1:ncpus=' in cluster.job_header
+        assert '#PBS -l walltime=' in cluster.job_header
+        assert '#PBS -A' not in cluster.job_header
+        assert '#PBS -q' not in cluster.job_header
+
+
+def test_job_script():
+    with PBSCluster(walltime='00:02:00', processes=4, threads=2, memory='7GB') as cluster:
+
+        job_script = cluster.job_script()
+        assert '#PBS' in job_script
+        assert '#PBS -N dask-worker' in job_script
+        assert '#PBS -l select=1:ncpus=8:mem=27GB' in job_script
+        assert '#PBS -l walltime=00:02:00' in job_script
+        assert '#PBS -q' not in job_script
+        assert '#PBS -A' not in job_script
+
+        assert '/dask-worker tcp://' in job_script
+        assert '--nthreads 2 --nprocs 4 --memory-limit 7GB' in job_script
+
+    with PBSCluster(queue='regular', project='DaskOnPBS', processes=4, threads=2, memory='7GB',
+                    resource_spec='select=1:ncpus=24:mem=100GB') as cluster:
+
+        job_script = cluster.job_script()
+        assert '#PBS -q regular' in job_script
+        assert '#PBS -N dask-worker' in job_script
+        assert '#PBS -l select=1:ncpus=24:mem=100GB' in job_script
+        assert '#PBS -l select=1:ncpus=8:mem=27GB' not in job_script
+        assert '#PBS -l walltime=' in job_script
+        assert '#PBS -A DaskOnPBS' in job_script
+
+        assert '/dask-worker tcp://' in job_script
+        assert '--nthreads 2 --nprocs 4 --memory-limit 7GB' in job_script

--- a/dask_jobqueue/tests/test_slurm.py
+++ b/dask_jobqueue/tests/test_slurm.py
@@ -7,7 +7,8 @@ from dask.distributed import Client
 from distributed.utils_test import loop  # noqa: F401
 from dask_jobqueue import SLURMCluster
 
-pytestmark = pytest.mark.env("pbs")
+#Run test only if py.test -E slurm is called
+pytestmark = pytest.mark.env("slurm")
 
 
 def test_basic(loop):  # noqa: F811

--- a/dask_jobqueue/tests/test_slurm_basic.py
+++ b/dask_jobqueue/tests/test_slurm_basic.py
@@ -1,0 +1,77 @@
+from dask_jobqueue import SLURMCluster
+
+#No mark in order to run these simple unit tests all the time
+
+
+def test_header():
+    with SLURMCluster(walltime='00:02:00', processes=4, threads=2, memory='7GB') as cluster:
+
+        assert '#SBATCH' in cluster.job_header
+        assert '#SBATCH -J dask-worker' in cluster.job_header
+        assert '#SBATCH -n 1' in cluster.job_header
+        assert '#SBATCH --cpus-per-task=8' in cluster.job_header
+        assert '#SBATCH --mem=27G' in cluster.job_header
+        assert '#SBATCH -t 00:02:00' in cluster.job_header
+        assert '#SBATCH -p' not in cluster.job_header
+        assert '#SBATCH -A' not in cluster.job_header
+
+    with SLURMCluster(queue='regular', project='DaskOnPBS', processes=4, threads=2, memory='7GB',
+                      job_cpu=16, job_mem='100G') as cluster:
+
+        assert '#SBATCH --cpus-per-task=16' in cluster.job_header
+        assert '#SBATCH --cpus-per-task=8' not in cluster.job_header
+        assert '#SBATCH --mem=100G' in cluster.job_header
+        assert '#SBATCH -t ' in cluster.job_header
+        assert '#SBATCH -A DaskOnPBS' in cluster.job_header
+        assert '#SBATCH -p regular' in cluster.job_header
+
+    with SLURMCluster() as cluster:
+
+        assert '#SBATCH' in cluster.job_header
+        assert '#SBATCH -J ' in cluster.job_header
+        assert '#SBATCH -n 1' in cluster.job_header
+        assert '#SBATCH --cpus-per-task=' in cluster.job_header
+        assert '#SBATCH --mem=' in cluster.job_header
+        assert '#SBATCH -t ' in cluster.job_header
+        assert '#SBATCH -p' not in cluster.job_header
+        assert '#SBATCH -A' not in cluster.job_header
+
+
+def test_job_script():
+    with SLURMCluster(walltime='00:02:00', processes=4, threads=2, memory='7GB') as cluster:
+
+        job_script = cluster.job_script()
+        assert '#SBATCH' in job_script
+        assert '#SBATCH -J dask-worker' in job_script
+        assert '#SBATCH -n 1' in job_script
+        assert '#SBATCH --cpus-per-task=8' in job_script
+        assert '#SBATCH --mem=27G' in job_script
+        assert '#SBATCH -t 00:02:00' in job_script
+        assert '#SBATCH -p' not in job_script
+        assert '#SBATCH -A' not in job_script
+
+        assert 'export ' not in job_script
+
+        assert '/dask-worker tcp://' in job_script
+        assert '--nthreads 2 --nprocs 4 --memory-limit 7GB' in job_script
+
+    with SLURMCluster(walltime='00:02:00', processes=4, threads=2, memory='7GB',
+                      env_extra=['export LANG="en_US.utf8"', 'export LANGUAGE="en_US.utf8"',
+                                 'export LC_ALL="en_US.utf8"']
+                      ) as cluster:
+        job_script = cluster.job_script()
+        assert '#SBATCH' in job_script
+        assert '#SBATCH -J dask-worker' in job_script
+        assert '#SBATCH -n 1' in job_script
+        assert '#SBATCH --cpus-per-task=8' in job_script
+        assert '#SBATCH --mem=27G' in job_script
+        assert '#SBATCH -t 00:02:00' in job_script
+        assert '#SBATCH -p' not in job_script
+        assert '#SBATCH -A' not in job_script
+
+        assert 'export LANG="en_US.utf8"' in job_script
+        assert 'export LANGUAGE="en_US.utf8"' in job_script
+        assert 'export LC_ALL="en_US.utf8"' in job_script
+
+        assert '/dask-worker tcp://' in job_script
+        assert '--nthreads 2 --nprocs 4 --memory-limit 7GB' in job_script


### PR DESCRIPTION
I've added some simple unit tests (testing that the worker job scripts was well formed) in order to have basic regression tests.
Those tests are also run into a Docker container, but no workers are launched, only constructor are tested, but basic methods could also be tested.

I was wondering if we still needed the conda install part in the .travis.yml:
```
  # Install miniconda
  - ./ci/conda_setup.sh
  - export PATH="$HOME/miniconda/bin:$PATH"
- conda install --yes -c conda-forge python=$TRAVIS_PYTHON_VERSION dask distributed flake8
```
If everything is done another time in Docker images, is there a need to do this in the base Travis envrionment?