### PR TITLE
Use released version of distributed.

### DIFF
--- a/ci/sge/Dockerfile-master
+++ b/ci/sge/Dockerfile-master
@@ -12,7 +12,6 @@ ENV PATH /opt/anaconda/bin:$PATH
 RUN conda install -n root conda=4.4.11 && conda clean -tipy
 RUN conda install -c conda-forge dask distributed blas pytest mock ipython pip psutil && conda clean -tipy
 RUN pip install --no-cache-dir drmaa
-RUN pip install --no-cache-dir git+https://github.com/dask/distributed.git --upgrade
 
 COPY ./*.sh /
 COPY ./*.txt /

--- a/ci/sge/Dockerfile-slave
+++ b/ci/sge/Dockerfile-slave
@@ -12,7 +12,6 @@ ENV PATH /opt/anaconda/bin:$PATH
 RUN conda install -n root conda=4.4.11 && conda clean -tipy
 RUN conda install -c conda-forge dask distributed blas pytest mock ipython pip psutil && conda clean -tipy
 RUN pip install --no-cache-dir drmaa
-RUN pip install --no-cache-dir git+https://github.com/dask/distributed.git --upgrade
 
 COPY ./setup-slave.sh /
 COPY ./*.sh /


### PR DESCRIPTION
At the time of writing you need to have both dask and distributed master because of the config overhaul (https://github.com/dask/distributed/pull/1948 and https://github.com/dask/dask/pull/3432). If you only have distributed from master you'll have an error like this:

```
❯ python -c 'from distributed import client'                    
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/lesteve/miniconda3/envs/tmp/lib/python3.6/site-packages/distributed/__init__.py", line 3, in <module>
    from . import config
  File "/home/lesteve/miniconda3/envs/tmp/lib/python3.6/site-packages/distributed/config.py", line 13, in <module>
    config = dask.config.config
AttributeError: module 'dask' has no attribute 'config'
```

Also this seems like a better idea to test against released version of distributed
in our CI, as the end user is very likely going to be using a released version of distributed.

Given that there was a relase of distributed 4 days ago, I reckon this is recent enough. We can always revert to testing against distributed if we need bleeding-edge features but I would rather fix master first.