### PR TITLE
fix typo in Slurm walltime

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -46,5 +46,5 @@ SLURM Deployments
                           threads=2,
                           memory="16GB",
                           project="woodshole",
-                          walltime="01:00",
+                          walltime="01:00:00",
                           queue="normal")


### PR DESCRIPTION
This typo in wall time (1 minute instead of 1 hour) was my fault, fixing here. 