### PR TITLE
add Slurm low-pri example deployment

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -48,3 +48,24 @@ SLURM Deployments
                           project="woodshole",
                           walltime="01:00:00",
                           queue="normal")
+
+
+
+SLURM Deployment: Low-priority node usage
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: python
+
+
+    from dask_jobqueue import SLURMCluster
+    cluster = SLURMCluster(processes=6, 
+                           threads=4, 
+                           memory="16GB", 
+                           project="co_laika", 
+                           queue='savio2_bigmem',
+                           env_extra=['export LANG="en_US.utf8"',
+                                      'export LANGUAGE="en_US.utf8"',
+                                      'export LC_ALL="en_US.utf8"', 
+                                      'qos="savio_lowprio"', 
+                                      'nodes="20"'])
+


### PR DESCRIPTION
Adding example deployment to documentation. Demonstrates usage of low-priority nodes and specifying cluster partitions. 