### PR TITLE
Add MoabCluster

### DIFF
--- a/dask_jobqueue/__init__.py
+++ b/dask_jobqueue/__init__.py
@@ -1,6 +1,7 @@
 # flake8: noqa
 from . import config
 from .core import JobQueueCluster
+from .moab import MoabCluster
 from .pbs import PBSCluster
 from .slurm import SLURMCluster
 from .sge import SGECluster

--- a/dask_jobqueue/moab.py
+++ b/dask_jobqueue/moab.py
@@ -24,8 +24,12 @@ class MoabCluster(PBSCluster):
 
     Examples
     --------
+    >>> import os
     >>> from dask_jobqueue import MoabCluster
-    >>> cluster = MoabCluster(queue='regular', project='DaskOnMoab')
+    >>> cluster = MoabCluster(processes=6, threads=1, project='gfdl_m',
+                              memory='16G', resource_spec='96G',
+                              job_extra=['-d /home/First.Last', '-M none'],
+                              local_directory=os.getenv('TMPDIR', '/tmp'))
     >>> cluster.start_workers(10)  # this may take a few seconds to launch
 
     >>> from dask.distributed import Client
@@ -35,15 +39,6 @@ class MoabCluster(PBSCluster):
     kill workers based on load.
 
     >>> cluster.adapt()
-
-    It is a good practice to define local_directory to your Moab system scratch
-    directory, and you should specify resource_spec according to the processes
-    and threads asked:
-
-    >>> cluster = MoabCluster(queue='regular', project='DaskOnMoab',
-                              local_directory=os.getenv('TMPDIR', '/tmp'),
-                              threads=4, processes=6, memory='16GB',
-                              resource_spec='select=1:ncpus=24:mem=100GB')
     """, 4)
     submit_command = 'msub'
     cancel_command = 'canceljob'

--- a/dask_jobqueue/moab.py
+++ b/dask_jobqueue/moab.py
@@ -1,0 +1,52 @@
+from .core import docstrings
+from .pbs import PBSCluster
+
+
+class MoabCluster(PBSCluster):
+    __doc__ = docstrings.with_indents("""Launch Dask on a Moab cluster
+
+    Parameters
+    ----------
+    queue : str
+        Destination queue for each worker job. Passed to `#PBS -q` option.
+    project : str
+        Accounting string associated with each worker job. Passed to
+        `#PBS -A` option.
+    resource_spec : str
+        Request resources and specify job placement. Passed to `#PBS -l`
+        option.
+    walltime : str
+        Walltime for each worker job.
+    job_extra : list
+        List of other PBS options, for example -j oe. Each option will be
+        prepended with the #PBS prefix.
+    %(JobQueueCluster.parameters)s
+
+    Examples
+    --------
+    >>> from dask_jobqueue import MoabCluster
+    >>> cluster = MoabCluster(queue='regular', project='DaskOnMoab')
+    >>> cluster.start_workers(10)  # this may take a few seconds to launch
+
+    >>> from dask.distributed import Client
+    >>> client = Client(cluster)
+
+    This also works with adaptive clusters.  This automatically launches and
+    kill workers based on load.
+
+    >>> cluster.adapt()
+
+    It is a good practice to define local_directory to your Moab system scratch
+    directory, and you should specify resource_spec according to the processes
+    and threads asked:
+
+    >>> cluster = MoabCluster(queue='regular', project='DaskOnMoab',
+                              local_directory=os.getenv('TMPDIR', '/tmp'),
+                              threads=4, processes=6, memory='16GB',
+                              resource_spec='select=1:ncpus=24:mem=100GB')
+    """, 4)
+    submit_command = 'msub'
+    cancel_command = 'canceljob'
+
+    def _job_id_from_submit_output(self, out):
+        return out.strip()

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -9,6 +9,7 @@ API
 .. autosummary::
    :toctree: generated/
 
+   MoabCluster
    PBSCluster
    SLURMCluster
    SGECluster

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -45,8 +45,7 @@ can be used, called ``MoabCluster``:
                          project='gfdl_m',
                          memory='16G',
                          resource_spec='pmem=96G',
-                         job_extra=['-d /home/First.Last', '-M none'],
-                         death_timeout=600)
+                         job_extra=['-d /home/First.Last', '-M none'])
                         
 SGE Deployments
 ---------------

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -38,6 +38,7 @@ can be used, called ``MoabCluster``:
 
 .. code-block:: python
 
+   import os
    from dask_jobqueue import MoabCluster
 
    cluster = MoabCluster(processes=6,
@@ -45,7 +46,8 @@ can be used, called ``MoabCluster``:
                          project='gfdl_m',
                          memory='16G',
                          resource_spec='pmem=96G',
-                         job_extra=['-d /home/First.Last', '-M none'])
+                         job_extra=['-d /home/First.Last', '-M none'],
+                         local_directory=os.getenv('TMPDIR', '/tmp'))
                         
 SGE Deployments
 ---------------

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -30,6 +30,24 @@ PBS Deployments
                         walltime='02:00:00',
                         interface='ib0')
 
+Moab Deployments
+~~~~~~~~~~~~~~~~
+
+On systems which use the Moab Workload Manager, a subclass of ``PBSCluster``
+can be used, called ``MoabCluster``:
+
+.. code-block:: python
+
+   from dask_jobqueue import MoabCluster
+
+   cluster = MoabCluster(processes=6,
+                         threads=1,
+                         project='gfdl_m',
+                         memory='16G',
+                         resource_spec='pmem=96G',
+                         job_extra=['-d /home/First.Last', '-M none'],
+                         death_timeout=600)
+                        
 SGE Deployments
 ---------------
 


### PR DESCRIPTION
As suggested in https://github.com/pangeo-data/pangeo/pull/284#discussion_r192569026 this adds a `MoabCluster` class to dask-jobqueue.  I also included an example with a configuration I've used at GFDL.

I'm not sure what we want to do about testing.  Do we need to set up a separate CI environment for testing with Moab, or is it sufficient to assume that if we have robust test coverage for `PBSCluster` that things should work properly?

cc: @guillaumeeb @jhamman