### PR TITLE
Separate configuration per resource manager

### DIFF
--- a/dask_jobqueue/core.py
+++ b/dask_jobqueue/core.py
@@ -77,17 +77,19 @@ class JobQueueCluster(Cluster):
     # Following class attributes should be overriden by extending classes.
     submit_command = None
     cancel_command = None
+    scheduler_name = ''
 
     def __init__(self,
-                 name=dask.config.get('jobqueue.name'),
-                 threads=dask.config.get('jobqueue.threads'),
-                 processes=dask.config.get('jobqueue.processes'),
-                 memory=dask.config.get('jobqueue.memory'),
-                 interface=dask.config.get('jobqueue.interface'),
-                 death_timeout=dask.config.get('jobqueue.death-timeout'),
-                 local_directory=dask.config.get('jobqueue.local-directory'),
-                 extra=dask.config.get('jobqueue.extra'),
-                 env_extra=dask.config.get('jobqueue.env-extra'),
+                 name=None,
+                 threads=None,
+                 processes=None,
+                 memory=None,
+                 interface=None,
+                 death_timeout=None,
+                 local_directory=None,
+                 extra=None,
+                 env_extra=None,
+                 walltime=None,
                  **kwargs
                  ):
         """ """
@@ -95,9 +97,19 @@ class JobQueueCluster(Cluster):
         # This initializer should be considered as Abstract, and never used
         # directly.
         # """
-        if not self.cancel_command or not self.submit_command:
+        if not self.scheduler_name:
             raise NotImplementedError('JobQueueCluster is an abstract class '
                                       'that should not be instanciated.')
+
+        name = name or dask.config.get('jobqueue.%s.name' % self.scheduler_name)
+        threads = threads or dask.config.get('jobqueue.%s.threads' % self.scheduler_name)
+        processes = processes or dask.config.get('jobqueue.%s.processes' % self.scheduler_name)
+        memory = memory or dask.config.get('jobqueue.%s.memory' % self.scheduler_name)
+        interface = interface or dask.config.get('jobqueue.%s.interface' % self.scheduler_name)
+        death_timeout = death_timeout or dask.config.get('jobqueue.%s.death-timeout' % self.scheduler_name)
+        local_directory = local_directory or dask.config.get('jobqueue.%s.local-directory' % self.scheduler_name)
+        extra = extra or dask.config.get('jobqueue.%s.extra' % self.scheduler_name)
+        env_extra = env_extra or dask.config.get('jobqueue.%s.env-extra' % self.scheduler_name)
 
         #This attribute should be overriden
         self.job_header = None

--- a/dask_jobqueue/core.py
+++ b/dask_jobqueue/core.py
@@ -101,15 +101,24 @@ class JobQueueCluster(Cluster):
             raise NotImplementedError('JobQueueCluster is an abstract class '
                                       'that should not be instanciated.')
 
-        name = name or dask.config.get('jobqueue.%s.name' % self.scheduler_name)
-        threads = threads or dask.config.get('jobqueue.%s.threads' % self.scheduler_name)
-        processes = processes or dask.config.get('jobqueue.%s.processes' % self.scheduler_name)
-        memory = memory or dask.config.get('jobqueue.%s.memory' % self.scheduler_name)
-        interface = interface or dask.config.get('jobqueue.%s.interface' % self.scheduler_name)
-        death_timeout = death_timeout or dask.config.get('jobqueue.%s.death-timeout' % self.scheduler_name)
-        local_directory = local_directory or dask.config.get('jobqueue.%s.local-directory' % self.scheduler_name)
-        extra = extra or dask.config.get('jobqueue.%s.extra' % self.scheduler_name)
-        env_extra = env_extra or dask.config.get('jobqueue.%s.env-extra' % self.scheduler_name)
+        if name is None:
+            name = dask.config.get('jobqueue.%s.name' % self.scheduler_name)
+        if threads is None:
+            threads = dask.config.get('jobqueue.%s.threads' % self.scheduler_name)
+        if processes is None:
+            processes = dask.config.get('jobqueue.%s.processes' % self.scheduler_name)
+        if memory is None:
+            memory = dask.config.get('jobqueue.%s.memory' % self.scheduler_name)
+        if interface is None:
+            interface = dask.config.get('jobqueue.%s.interface' % self.scheduler_name)
+        if death_timeout is None:
+            death_timeout = dask.config.get('jobqueue.%s.death-timeout' % self.scheduler_name)
+        if local_directory is None:
+            local_directory = dask.config.get('jobqueue.%s.local-directory' % self.scheduler_name)
+        if extra is None:
+            extra = dask.config.get('jobqueue.%s.extra' % self.scheduler_name)
+        if env_extra is None:
+            env_extra = dask.config.get('jobqueue.%s.env-extra' % self.scheduler_name)
 
         #This attribute should be overriden
         self.job_header = None

--- a/dask_jobqueue/jobqueue.yaml
+++ b/dask_jobqueue/jobqueue.yaml
@@ -1,26 +1,81 @@
 jobqueue:
-  name: dask-worker
-  threads: 2
-  processes: 4
-  memory: 8GB
-  interface: null
-  death-timeout: 60
-  local-directory: null
-  extra: ""
-  env-extra: []
-
-  queue: null
-  project: null
-  walltime: '00:30:00'
-
   pbs:
+    name: dask-worker
+
+    # Dask worker options
+    threads: 2
+    processes: 4
+    memory: 8GB
+    interface: null
+    death-timeout: 60
+    local-directory: null
+
+    # PBS resource manager options
+    queue: null
+    project: null
+    walltime: '00:30:00'
+    extra: ""
+    env-extra: []
     resource-spec: null
     job-extra: []
 
   sge:
+    name: dask-worker
+
+    # Dask worker options
+    threads: 2
+    processes: 4
+    memory: 8GB
+    interface: null
+    death-timeout: 60
+    local-directory: null
+
+    # SGE resource manager options
+    queue: null
+    project: null
+    walltime: '00:30:00'
+    extra: ""
+    env-extra: []
+
     resource-spec: null
 
   slurm:
+    name: dask-worker
+
+    # Dask worker options
+    threads: 2
+    processes: 4
+    memory: 8GB
+    interface: null
+    death-timeout: 60
+    local-directory: null
+
+    # SLURM resource manager options
+    queue: null
+    project: null
+    walltime: '00:30:00'
+    extra: ""
+    env-extra: []
     job-cpu: null
     job-mem: null
     job-extra: {}
+
+  moab:
+    name: dask-worker
+
+    # Dask worker options
+    threads: 2
+    processes: 4
+    memory: 8GB
+    interface: null
+    death-timeout: 60
+    local-directory: null
+
+    # PBS resource manager options
+    queue: null
+    project: null
+    walltime: '00:30:00'
+    extra: ""
+    env-extra: []
+    resource-spec: null
+    job-extra: []

--- a/dask_jobqueue/moab.py
+++ b/dask_jobqueue/moab.py
@@ -42,6 +42,7 @@ class MoabCluster(PBSCluster):
     """, 4)
     submit_command = 'msub'
     cancel_command = 'canceljob'
+    scheduler_name = 'moab'
 
     def _job_id_from_submit_output(self, out):
         return out.strip()

--- a/dask_jobqueue/pbs.py
+++ b/dask_jobqueue/pbs.py
@@ -58,20 +58,21 @@ class PBSCluster(JobQueueCluster):
     # Override class variables
     submit_command = 'qsub'
     cancel_command = 'qdel'
+    scheduler_name = 'pbs'
 
-    def __init__(self,
-                 queue=dask.config.get('jobqueue.queue'),
-                 project=dask.config.get('jobqueue.project'),
-                 resource_spec=dask.config.get('jobqueue.pbs.resource-spec'),
-                 walltime=dask.config.get('jobqueue.walltime'),
-                 job_extra=dask.config.get('jobqueue.pbs.job-extra'),
-                 **kwargs):
+    def __init__(self, *args, queue=None, project=None, resource_spec=None, walltime=None, job_extra=None, **kwargs):
+        if queue is None:
+            queue = dask.config.get('jobqueue.%s.queue' % self.scheduler_name)
+        if resource_spec is None:
+            resource_spec = dask.config.get('jobqueue.%s.resource-spec' % self.scheduler_name)
+        if walltime is None:
+            walltime = dask.config.get('jobqueue.%s.walltime' % self.scheduler_name)
+        if job_extra is None:
+            job_extra = dask.config.get('jobqueue.%s.job-extra' % self.scheduler_name)
+        project = project or dask.config.get('jobqueue.%s.project' % self.scheduler_name) or os.environ.get('PBS_ACCOUNT')
 
         # Instantiate args and parameters from parent abstract class
-        super(PBSCluster, self).__init__(**kwargs)
-
-        # Try to find a project name from environment variable
-        project = project or os.environ.get('PBS_ACCOUNT')
+        super(PBSCluster, self).__init__(*args, **kwargs)
 
         header_lines = []
         # PBS header build

--- a/dask_jobqueue/pbs.py
+++ b/dask_jobqueue/pbs.py
@@ -60,7 +60,7 @@ class PBSCluster(JobQueueCluster):
     cancel_command = 'qdel'
     scheduler_name = 'pbs'
 
-    def __init__(self, *args, queue=None, project=None, resource_spec=None, walltime=None, job_extra=None, **kwargs):
+    def __init__(self, queue=None, project=None, resource_spec=None, walltime=None, job_extra=None, **kwargs):
         if queue is None:
             queue = dask.config.get('jobqueue.%s.queue' % self.scheduler_name)
         if resource_spec is None:
@@ -72,7 +72,7 @@ class PBSCluster(JobQueueCluster):
         project = project or dask.config.get('jobqueue.%s.project' % self.scheduler_name) or os.environ.get('PBS_ACCOUNT')
 
         # Instantiate args and parameters from parent abstract class
-        super(PBSCluster, self).__init__(*args, **kwargs)
+        super(PBSCluster, self).__init__(**kwargs)
 
         header_lines = []
         # PBS header build

--- a/dask_jobqueue/pbs.py
+++ b/dask_jobqueue/pbs.py
@@ -50,9 +50,9 @@ class PBSCluster(JobQueueCluster):
     and threads asked:
 
     >>> cluster = PBSCluster(queue='regular', project='DaskOnPBS',
-                             local_directory=os.getenv('TMPDIR', '/tmp'),
-                             threads=4, processes=6, memory='16GB',
-                             resource_spec='select=1:ncpus=24:mem=100GB')
+    ...                      local_directory=os.getenv('TMPDIR', '/tmp'),
+    ...                      threads=4, processes=6, memory='16GB',
+    ...                      resource_spec='select=1:ncpus=24:mem=100GB')
     """, 4)
 
     # Override class variables
@@ -69,7 +69,8 @@ class PBSCluster(JobQueueCluster):
             walltime = dask.config.get('jobqueue.%s.walltime' % self.scheduler_name)
         if job_extra is None:
             job_extra = dask.config.get('jobqueue.%s.job-extra' % self.scheduler_name)
-        project = project or dask.config.get('jobqueue.%s.project' % self.scheduler_name) or os.environ.get('PBS_ACCOUNT')
+        if project is None:
+            project = dask.config.get('jobqueue.%s.project' % self.scheduler_name) or os.environ.get('PBS_ACCOUNT')
 
         # Instantiate args and parameters from parent abstract class
         super(PBSCluster, self).__init__(**kwargs)

--- a/dask_jobqueue/sge.py
+++ b/dask_jobqueue/sge.py
@@ -44,7 +44,7 @@ class SGECluster(JobQueueCluster):
     cancel_command = 'qdel'
     scheduler_name = 'sge'
 
-    def __init__(self, *args, queue=None, project=None, resource_spec=None, walltime=None, **kwargs):
+    def __init__(self, queue=None, project=None, resource_spec=None, walltime=None, **kwargs):
         if queue is None:
             queue = dask.config.get('jobqueue.%s.queue' % self.scheduler_name)
         if project is None:
@@ -54,7 +54,7 @@ class SGECluster(JobQueueCluster):
         if walltime is None:
             walltime = dask.config.get('jobqueue.%s.walltime' % self.scheduler_name)
 
-        super(SGECluster, self).__init__(*args, **kwargs)
+        super(SGECluster, self).__init__(**kwargs)
 
         header_lines = ['#!/bin/bash']
 

--- a/dask_jobqueue/sge.py
+++ b/dask_jobqueue/sge.py
@@ -42,15 +42,19 @@ class SGECluster(JobQueueCluster):
     # Override class variables
     submit_command = 'qsub -terse'
     cancel_command = 'qdel'
+    scheduler_name = 'sge'
 
-    def __init__(self,
-                 queue=dask.config.get('jobqueue.queue'),
-                 project=dask.config.get('jobqueue.project'),
-                 resource_spec=dask.config.get('jobqueue.sge.resource-spec'),
-                 walltime=dask.config.get('jobqueue.walltime'),
-                 **kwargs):
+    def __init__(self, *args, queue=None, project=None, resource_spec=None, walltime=None, **kwargs):
+        if queue is None:
+            queue = dask.config.get('jobqueue.%s.queue' % self.scheduler_name)
+        if project is None:
+            project = dask.config.get('jobqueue.%s.project' % self.scheduler_name)
+        if resource_spec is None:
+            resource_spec = dask.config.get('jobqueue.%s.resource-spec' % self.scheduler_name)
+        if walltime is None:
+            walltime = dask.config.get('jobqueue.%s.walltime' % self.scheduler_name)
 
-        super(SGECluster, self).__init__(**kwargs)
+        super(SGECluster, self).__init__(*args, **kwargs)
 
         header_lines = ['#!/bin/bash']
 

--- a/dask_jobqueue/slurm.py
+++ b/dask_jobqueue/slurm.py
@@ -60,7 +60,7 @@ class SLURMCluster(JobQueueCluster):
     cancel_command = 'scancel'
     scheduler_name = 'slurm'
 
-    def __init__(self, *args, queue=None, project=None, walltime=None,
+    def __init__(self, queue=None, project=None, walltime=None,
             job_cpu=None, job_mem=None, job_extra=None, **kwargs):
         if queue is None:
             queue = dask.config.get('jobqueue.slurm.queue')
@@ -75,7 +75,7 @@ class SLURMCluster(JobQueueCluster):
         if job_extra is None:
             job_extra = dask.config.get('jobqueue.slurm.job-extra')
 
-        super(SLURMCluster, self).__init__(*args, **kwargs)
+        super(SLURMCluster, self).__init__(**kwargs)
 
         # Always ask for only one task
         header_lines = []

--- a/dask_jobqueue/slurm.py
+++ b/dask_jobqueue/slurm.py
@@ -61,7 +61,7 @@ class SLURMCluster(JobQueueCluster):
     scheduler_name = 'slurm'
 
     def __init__(self, queue=None, project=None, walltime=None,
-            job_cpu=None, job_mem=None, job_extra=None, **kwargs):
+                 job_cpu=None, job_mem=None, job_extra=None, **kwargs):
         if queue is None:
             queue = dask.config.get('jobqueue.slurm.queue')
         if project is None:

--- a/dask_jobqueue/slurm.py
+++ b/dask_jobqueue/slurm.py
@@ -58,17 +58,24 @@ class SLURMCluster(JobQueueCluster):
     #Override class variables
     submit_command = 'sbatch --parsable'
     cancel_command = 'scancel'
+    scheduler_name = 'slurm'
 
-    def __init__(self,
-                 queue=dask.config.get('jobqueue.queue'),
-                 project=dask.config.get('jobqueue.project'),
-                 walltime=dask.config.get('jobqueue.walltime'),
-                 job_cpu=dask.config.get('jobqueue.slurm.job-cpu'),
-                 job_mem=dask.config.get('jobqueue.slurm.job-mem'),
-                 job_extra=dask.config.get('jobqueue.slurm.job-extra'),
-                 **kwargs):
+    def __init__(self, *args, queue=None, project=None, walltime=None,
+            job_cpu=None, job_mem=None, job_extra=None, **kwargs):
+        if queue is None:
+            queue = dask.config.get('jobqueue.slurm.queue')
+        if project is None:
+            project = dask.config.get('jobqueue.slurm.project')
+        if walltime is None:
+            walltime = dask.config.get('jobqueue.slurm.walltime')
+        if job_cpu is None:
+            job_cpu = dask.config.get('jobqueue.slurm.job-cpu')
+        if job_mem is None:
+            job_mem = dask.config.get('jobqueue.slurm.job-mem')
+        if job_extra is None:
+            job_extra = dask.config.get('jobqueue.slurm.job-extra')
 
-        super(SLURMCluster, self).__init__(**kwargs)
+        super(SLURMCluster, self).__init__(*args, **kwargs)
 
         # Always ask for only one task
         header_lines = []

--- a/dask_jobqueue/tests/test_pbs.py
+++ b/dask_jobqueue/tests/test_pbs.py
@@ -2,6 +2,7 @@ import sys
 from time import sleep, time
 
 import dask
+from dask.distributed import Client
 from distributed.utils_test import loop  # noqa: F401
 import pytest
 


### PR DESCRIPTION
Previously we maintained common configuration elements like name,
threads, and processes in the toplevel jobqueue config namespace.

Now we pull these out into each cluster's config namespace.

This also forces us to pick out config values at object instantiation
time, which should help with changing config values at runtime.

Fixes #68