### PR TITLE
set `self.worker_memory` to None when appropriate

### DIFF
--- a/dask_jobqueue/core.py
+++ b/dask_jobqueue/core.py
@@ -112,7 +112,7 @@ class JobQueueCluster(Cluster):
 
         # Keep information on process, threads and memory, for use in
         # subclasses
-        self.worker_memory = parse_bytes(memory)
+        self.worker_memory = parse_bytes(memory) if memory is not None else None
         self.worker_processes = processes
         self.worker_threads = threads
         self.name = name


### PR DESCRIPTION
We currently have a misconfigured SLURM setup where we can't specify the memory.

Therefore using `dask_jobqueue` always leads to a `Memory specification can not be satisfied` error, even when `memory=None`. This PR fixes that problem.