### PR TITLE
Find dask-worker through the interpreter rather than assume a location

### DIFF
--- a/dask_jobqueue/core.py
+++ b/dask_jobqueue/core.py
@@ -12,7 +12,10 @@ from distributed import LocalCluster
 from distributed.deploy import Cluster
 from distributed.utils import get_ip_interface, ignoring, parse_bytes, tmpfile
 
-dirname = os.path.dirname(sys.executable)
+worker_bin_path = (
+    '%(python)s -m distributed.cli.dask_worker'
+    % dict(python=sys.executable)
+)
 
 logger = logging.getLogger(__name__)
 docstrings = docrep.DocstringProcessor()
@@ -124,8 +127,8 @@ class JobQueueCluster(Cluster):
         self._env_header = '\n'.join(env_extra)
 
         # dask-worker command line build
-        self._command_template = os.path.join(
-            dirname, 'dask-worker %s' % self.scheduler.address)
+        self._command_template = ' '.join([
+            worker_bin_path, '%s' % self.scheduler.address])
         if threads is not None:
             self._command_template += " --nthreads %d" % threads
         if processes is not None:

--- a/dask_jobqueue/core.py
+++ b/dask_jobqueue/core.py
@@ -1,5 +1,4 @@
 import logging
-import os
 import shlex
 import socket
 import subprocess
@@ -11,11 +10,6 @@ import docrep
 from distributed import LocalCluster
 from distributed.deploy import Cluster
 from distributed.utils import get_ip_interface, ignoring, parse_bytes, tmpfile
-
-worker_bin_path = (
-    '%(python)s -m distributed.cli.dask_worker'
-    % dict(python=sys.executable)
-)
 
 logger = logging.getLogger(__name__)
 docstrings = docrep.DocstringProcessor()
@@ -127,8 +121,9 @@ class JobQueueCluster(Cluster):
         self._env_header = '\n'.join(env_extra)
 
         # dask-worker command line build
-        self._command_template = ' '.join([
-            worker_bin_path, '%s' % self.scheduler.address])
+        dask_worker_command = (
+            '%(python)s -m distributed.cli.dask_worker' % dict(python=sys.executable))
+        self._command_template = ' '.join([dask_worker_command, self.scheduler.address])
         if threads is not None:
             self._command_template += " --nthreads %d" % threads
         if processes is not None:

--- a/dask_jobqueue/slurm.py
+++ b/dask_jobqueue/slurm.py
@@ -11,8 +11,6 @@ from .core import JobQueueCluster, docstrings
 
 logger = logging.getLogger(__name__)
 
-dirname = os.path.dirname(sys.executable)
-
 
 class SLURMCluster(JobQueueCluster):
     __doc__ = docstrings.with_indents(""" Launch Dask on a SLURM cluster

--- a/dask_jobqueue/slurm.py
+++ b/dask_jobqueue/slurm.py
@@ -2,8 +2,6 @@ from __future__ import absolute_import, division, print_function
 
 import logging
 import math
-import os
-import sys
 
 import dask
 

--- a/dask_jobqueue/tests/test_pbs.py
+++ b/dask_jobqueue/tests/test_pbs.py
@@ -57,7 +57,7 @@ def test_job_script():
         assert '#PBS -q' not in job_script
         assert '#PBS -A' not in job_script
 
-        assert '/dask-worker tcp://' in job_script
+        assert '-m distributed.cli.dask_worker tcp://' in job_script
         assert '--nthreads 2 --nprocs 4 --memory-limit 7GB' in job_script
 
     with PBSCluster(queue='regular', project='DaskOnPBS', processes=4, threads=2, memory='7GB',
@@ -71,7 +71,7 @@ def test_job_script():
         assert '#PBS -l walltime=' in job_script
         assert '#PBS -A DaskOnPBS' in job_script
 
-        assert 'dask-worker tcp://' in job_script
+        assert '-m distributed.cli.dask_worker tcp://' in job_script
         assert '--nthreads 2 --nprocs 4 --memory-limit 7GB' in job_script
 
 

--- a/dask_jobqueue/tests/test_pbs.py
+++ b/dask_jobqueue/tests/test_pbs.py
@@ -57,7 +57,7 @@ def test_job_script():
         assert '#PBS -q' not in job_script
         assert '#PBS -A' not in job_script
 
-        assert '-m distributed.cli.dask_worker tcp://' in job_script
+        assert 'python -m distributed.cli.dask_worker tcp://' in job_script
         assert '--nthreads 2 --nprocs 4 --memory-limit 7GB' in job_script
 
     with PBSCluster(queue='regular', project='DaskOnPBS', processes=4, threads=2, memory='7GB',
@@ -71,7 +71,7 @@ def test_job_script():
         assert '#PBS -l walltime=' in job_script
         assert '#PBS -A DaskOnPBS' in job_script
 
-        assert '-m distributed.cli.dask_worker tcp://' in job_script
+        assert 'python -m distributed.cli.dask_worker tcp://' in job_script
         assert '--nthreads 2 --nprocs 4 --memory-limit 7GB' in job_script
 
 

--- a/dask_jobqueue/tests/test_pbs.py
+++ b/dask_jobqueue/tests/test_pbs.py
@@ -71,7 +71,7 @@ def test_job_script():
         assert '#PBS -l walltime=' in job_script
         assert '#PBS -A DaskOnPBS' in job_script
 
-        assert '/dask-worker tcp://' in job_script
+        assert 'dask-worker tcp://' in job_script
         assert '--nthreads 2 --nprocs 4 --memory-limit 7GB' in job_script
 
 

--- a/dask_jobqueue/tests/test_pbs.py
+++ b/dask_jobqueue/tests/test_pbs.py
@@ -57,7 +57,7 @@ def test_job_script():
         assert '#PBS -q' not in job_script
         assert '#PBS -A' not in job_script
 
-        assert 'python -m distributed.cli.dask_worker tcp://' in job_script
+        assert '{} -m distributed.cli.dask_worker tcp://'.format(sys.executable) in job_script
         assert '--nthreads 2 --nprocs 4 --memory-limit 7GB' in job_script
 
     with PBSCluster(queue='regular', project='DaskOnPBS', processes=4, threads=2, memory='7GB',
@@ -71,7 +71,7 @@ def test_job_script():
         assert '#PBS -l walltime=' in job_script
         assert '#PBS -A DaskOnPBS' in job_script
 
-        assert 'python -m distributed.cli.dask_worker tcp://' in job_script
+        assert '{} -m distributed.cli.dask_worker tcp://'.format(sys.executable) in job_script
         assert '--nthreads 2 --nprocs 4 --memory-limit 7GB' in job_script
 
 

--- a/dask_jobqueue/tests/test_pbs.py
+++ b/dask_jobqueue/tests/test_pbs.py
@@ -1,6 +1,7 @@
 from time import sleep, time
 
 import pytest
+import sys
 from distributed import Client
 from distributed.utils_test import loop  # noqa: F401
 

--- a/dask_jobqueue/tests/test_slurm.py
+++ b/dask_jobqueue/tests/test_slurm.py
@@ -77,7 +77,7 @@ def test_job_script():
         assert 'export LANGUAGE="en_US.utf8"' in job_script
         assert 'export LC_ALL="en_US.utf8"' in job_script
 
-        assert '/dask-worker tcp://' in job_script
+        assert 'dask-worker tcp://' in job_script
         assert '--nthreads 2 --nprocs 4 --memory-limit 7GB' in job_script
 
 

--- a/dask_jobqueue/tests/test_slurm.py
+++ b/dask_jobqueue/tests/test_slurm.py
@@ -56,7 +56,7 @@ def test_job_script():
 
         assert 'export ' not in job_script
 
-        assert '/dask-worker tcp://' in job_script
+        assert '-m distributed.cli.dask_worker tcp://' in job_script
         assert '--nthreads 2 --nprocs 4 --memory-limit 7GB' in job_script
 
     with SLURMCluster(walltime='00:02:00', processes=4, threads=2, memory='7GB',
@@ -77,7 +77,7 @@ def test_job_script():
         assert 'export LANGUAGE="en_US.utf8"' in job_script
         assert 'export LC_ALL="en_US.utf8"' in job_script
 
-        assert 'dask-worker tcp://' in job_script
+        assert '-m distributed.cli.dask_worker tcp://' in job_script
         assert '--nthreads 2 --nprocs 4 --memory-limit 7GB' in job_script
 
 

--- a/dask_jobqueue/tests/test_slurm.py
+++ b/dask_jobqueue/tests/test_slurm.py
@@ -56,7 +56,7 @@ def test_job_script():
 
         assert 'export ' not in job_script
 
-        assert '-m distributed.cli.dask_worker tcp://' in job_script
+        assert 'python -m distributed.cli.dask_worker tcp://' in job_script
         assert '--nthreads 2 --nprocs 4 --memory-limit 7GB' in job_script
 
     with SLURMCluster(walltime='00:02:00', processes=4, threads=2, memory='7GB',
@@ -77,7 +77,7 @@ def test_job_script():
         assert 'export LANGUAGE="en_US.utf8"' in job_script
         assert 'export LC_ALL="en_US.utf8"' in job_script
 
-        assert '-m distributed.cli.dask_worker tcp://' in job_script
+        assert 'python -m distributed.cli.dask_worker tcp://' in job_script
         assert '--nthreads 2 --nprocs 4 --memory-limit 7GB' in job_script
 
 

--- a/dask_jobqueue/tests/test_slurm.py
+++ b/dask_jobqueue/tests/test_slurm.py
@@ -1,6 +1,7 @@
 from time import sleep, time
 
 import pytest
+import sys
 from distributed import Client
 from distributed.utils_test import loop  # noqa: F401
 

--- a/dask_jobqueue/tests/test_slurm.py
+++ b/dask_jobqueue/tests/test_slurm.py
@@ -56,7 +56,7 @@ def test_job_script():
 
         assert 'export ' not in job_script
 
-        assert 'python -m distributed.cli.dask_worker tcp://' in job_script
+        assert '{} -m distributed.cli.dask_worker tcp://'.format(sys.executable) in job_script
         assert '--nthreads 2 --nprocs 4 --memory-limit 7GB' in job_script
 
     with SLURMCluster(walltime='00:02:00', processes=4, threads=2, memory='7GB',
@@ -77,7 +77,7 @@ def test_job_script():
         assert 'export LANGUAGE="en_US.utf8"' in job_script
         assert 'export LC_ALL="en_US.utf8"' in job_script
 
-        assert 'python -m distributed.cli.dask_worker tcp://' in job_script
+        assert '{} -m distributed.cli.dask_worker tcp://'.format(sys.executable) in job_script
         assert '--nthreads 2 --nprocs 4 --memory-limit 7GB' in job_script
 
 


### PR DESCRIPTION
Fixes #75 (at least for our system)