### PR TITLE
Rename JobQueueCluster cluster attribute to local_cluster

### DIFF
--- a/dask_jobqueue/core.py
+++ b/dask_jobqueue/core.py
@@ -126,7 +126,7 @@ class JobQueueCluster(Cluster):
         else:
             host = socket.gethostname()
 
-        self.cluster = LocalCluster(n_workers=0, ip=host, **kwargs)
+        self.local_cluster = LocalCluster(n_workers=0, ip=host, **kwargs)
 
         # Keep information on process, threads and memory, for use in
         # subclasses
@@ -191,7 +191,7 @@ class JobQueueCluster(Cluster):
     @property
     def scheduler(self):
         """ The scheduler of this cluster """
-        return self.cluster.scheduler
+        return self.local_cluster.scheduler
 
     def _calls(self, cmds):
         """ Call a command using subprocess.communicate
@@ -261,7 +261,7 @@ class JobQueueCluster(Cluster):
 
     def __exit__(self, type, value, traceback):
         self.stop_workers(self.jobs)
-        self.cluster.__exit__(type, value, traceback)
+        self.local_cluster.__exit__(type, value, traceback)
 
     def _job_id_from_submit_output(self, out):
         raise NotImplementedError('_job_id_from_submit_output must be '


### PR DESCRIPTION
This avoids things like `client.cluster.cluster` to access the `LocalCluster` object (yes `.cluster` appears twice, not a typo) which is a bit confusing.

I used the same attribute name as in dask-drmaa [here](https://github.com/dask/dask-drmaa/blob/c909d153ab3eafe354f3a55a5eb696246b937643/dask_drmaa/core.py#L161).

I reckon this is a bit of an implementation detail and is unlikely to affect anyone but I may be wrong about this so do share you concerns if you have some!