### PR TITLE
Add flexibility to the slurm implementation

### DIFF
--- a/dask_jobqueue/jobqueue.yaml
+++ b/dask_jobqueue/jobqueue.yaml
@@ -56,6 +56,7 @@ jobqueue:
     walltime: '00:30:00'
     extra: ""
     env-extra: []
+    job-nodes: null
     job-cpu: null
     job-mem: null
     job-extra: {}

--- a/dask_jobqueue/slurm.py
+++ b/dask_jobqueue/slurm.py
@@ -85,9 +85,12 @@ class SLURMCluster(JobQueueCluster):
         if project is not None:
             header_lines.append('#SBATCH -A %s' % project)
 
-        # Init resources, always 1 task,
+        # Init resources, always 1 task on 1 node (doing it this
+        # way rather than with the equivalent '-n 1' gives the user
+        # the flexibility to override these settings with job_extra)
+        header_lines.append('#SBATCH -N 1')
+        header_lines.append('#SBATCH --tasks-per-node=1')
         # and then number of cpu is processes * threads if not set
-        header_lines.append('#SBATCH -n 1')
         ncpus = job_cpu
         if ncpus is None:
             ncpus = self.worker_processes * self.worker_threads

--- a/dask_jobqueue/tests/test_slurm.py
+++ b/dask_jobqueue/tests/test_slurm.py
@@ -48,7 +48,26 @@ def test_job_script():
         job_script = cluster.job_script()
         assert '#SBATCH' in job_script
         assert '#SBATCH -J dask-worker' in job_script
-        assert '#SBATCH -n 1' in cluster.job_header
+        assert '#SBATCH -n 1' in job_script
+        assert '#SBATCH --cpus-per-task=8' in job_script
+        assert '#SBATCH --mem=27G' in job_script
+        assert '#SBATCH -t 00:02:00' in job_script
+        assert '#SBATCH -p' not in job_script
+        assert '#SBATCH -A' not in job_script
+
+        assert 'export ' not in job_script
+
+        assert '{} -m distributed.cli.dask_worker tcp://'.format(sys.executable) in job_script
+        assert '--nthreads 2 --nprocs 4 --memory-limit 7GB' in job_script
+
+    with SLURMCluster(walltime='00:02:00', processes=4, threads=2, memory='7GB',
+                      job_nodes=1) as cluster:
+
+        job_script = cluster.job_script()
+        assert '#SBATCH' in job_script
+        assert '#SBATCH -J dask-worker' in job_script
+        assert '#SBATCH -N 1' in job_script
+        assert '#SBATCH --tasks-per-node=1' in job_script
         assert '#SBATCH --cpus-per-task=8' in job_script
         assert '#SBATCH --mem=27G' in job_script
         assert '#SBATCH -t 00:02:00' in job_script
@@ -67,7 +86,7 @@ def test_job_script():
         job_script = cluster.job_script()
         assert '#SBATCH' in job_script
         assert '#SBATCH -J dask-worker' in job_script
-        assert '#SBATCH -n 1' in cluster.job_header
+        assert '#SBATCH -n 1' in job_script
         assert '#SBATCH --cpus-per-task=8' in job_script
         assert '#SBATCH --mem=27G' in job_script
         assert '#SBATCH -t 00:02:00' in job_script

--- a/dask_jobqueue/tests/test_slurm.py
+++ b/dask_jobqueue/tests/test_slurm.py
@@ -13,7 +13,8 @@ def test_header():
 
         assert '#SBATCH' in cluster.job_header
         assert '#SBATCH -J dask-worker' in cluster.job_header
-        assert '#SBATCH -n 1' in cluster.job_header
+        assert '#SBATCH -N 1' in cluster.job_header
+        assert '#SBATCH --tasks-per-node=1' in cluster.job_header
         assert '#SBATCH --cpus-per-task=8' in cluster.job_header
         assert '#SBATCH --mem=27G' in cluster.job_header
         assert '#SBATCH -t 00:02:00' in cluster.job_header
@@ -34,7 +35,8 @@ def test_header():
 
         assert '#SBATCH' in cluster.job_header
         assert '#SBATCH -J ' in cluster.job_header
-        assert '#SBATCH -n 1' in cluster.job_header
+        assert '#SBATCH -N 1' in cluster.job_header
+        assert '#SBATCH --tasks-per-node=1' in cluster.job_header
         assert '#SBATCH --cpus-per-task=' in cluster.job_header
         assert '#SBATCH --mem=' in cluster.job_header
         assert '#SBATCH -t ' in cluster.job_header
@@ -48,7 +50,8 @@ def test_job_script():
         job_script = cluster.job_script()
         assert '#SBATCH' in job_script
         assert '#SBATCH -J dask-worker' in job_script
-        assert '#SBATCH -n 1' in job_script
+        assert '#SBATCH -N 1' in cluster.job_header
+        assert '#SBATCH --tasks-per-node=1' in cluster.job_header
         assert '#SBATCH --cpus-per-task=8' in job_script
         assert '#SBATCH --mem=27G' in job_script
         assert '#SBATCH -t 00:02:00' in job_script
@@ -67,7 +70,8 @@ def test_job_script():
         job_script = cluster.job_script()
         assert '#SBATCH' in job_script
         assert '#SBATCH -J dask-worker' in job_script
-        assert '#SBATCH -n 1' in job_script
+        assert '#SBATCH -N 1' in cluster.job_header
+        assert '#SBATCH --tasks-per-node=1' in cluster.job_header
         assert '#SBATCH --cpus-per-task=8' in job_script
         assert '#SBATCH --mem=27G' in job_script
         assert '#SBATCH -t 00:02:00' in job_script

--- a/dask_jobqueue/tests/test_slurm.py
+++ b/dask_jobqueue/tests/test_slurm.py
@@ -13,8 +13,7 @@ def test_header():
 
         assert '#SBATCH' in cluster.job_header
         assert '#SBATCH -J dask-worker' in cluster.job_header
-        assert '#SBATCH -N 1' in cluster.job_header
-        assert '#SBATCH --tasks-per-node=1' in cluster.job_header
+        assert '#SBATCH -n 1' in cluster.job_header
         assert '#SBATCH --cpus-per-task=8' in cluster.job_header
         assert '#SBATCH --mem=27G' in cluster.job_header
         assert '#SBATCH -t 00:02:00' in cluster.job_header
@@ -35,8 +34,7 @@ def test_header():
 
         assert '#SBATCH' in cluster.job_header
         assert '#SBATCH -J ' in cluster.job_header
-        assert '#SBATCH -N 1' in cluster.job_header
-        assert '#SBATCH --tasks-per-node=1' in cluster.job_header
+        assert '#SBATCH -n 1' in cluster.job_header
         assert '#SBATCH --cpus-per-task=' in cluster.job_header
         assert '#SBATCH --mem=' in cluster.job_header
         assert '#SBATCH -t ' in cluster.job_header
@@ -50,8 +48,7 @@ def test_job_script():
         job_script = cluster.job_script()
         assert '#SBATCH' in job_script
         assert '#SBATCH -J dask-worker' in job_script
-        assert '#SBATCH -N 1' in cluster.job_header
-        assert '#SBATCH --tasks-per-node=1' in cluster.job_header
+        assert '#SBATCH -n 1' in cluster.job_header
         assert '#SBATCH --cpus-per-task=8' in job_script
         assert '#SBATCH --mem=27G' in job_script
         assert '#SBATCH -t 00:02:00' in job_script
@@ -70,8 +67,7 @@ def test_job_script():
         job_script = cluster.job_script()
         assert '#SBATCH' in job_script
         assert '#SBATCH -J dask-worker' in job_script
-        assert '#SBATCH -N 1' in cluster.job_header
-        assert '#SBATCH --tasks-per-node=1' in cluster.job_header
+        assert '#SBATCH -n 1' in cluster.job_header
         assert '#SBATCH --cpus-per-task=8' in job_script
         assert '#SBATCH --mem=27G' in job_script
         assert '#SBATCH -t 00:02:00' in job_script


### PR DESCRIPTION
The current slurm implementation sets
```
#SBATCH -n 1
``` 
which is fine but there is a more flexible equivalent implementation (which allocates a single task on a single node)
```
#SBATCH -N 1
#SBATCH --tasks-per-node=1
```
This is more flexible because it allows overriding these settings through `job_extra` so that  jobqueue can allocate multi-node jobs. 

I tried to explain our use case (poorly) in #62 , but I have a [gist](https://gist.github.com/ocaisa/9c4d68bae0970b2af637f45322121238) now that hopefully does that a bit better. 