### PR TITLE
Add cores and total_memory parameters

### DIFF
--- a/dask_jobqueue/core.py
+++ b/dask_jobqueue/core.py
@@ -138,7 +138,11 @@ class JobQueueCluster(Cluster):
 
         if cores is None:
             raise ValueError("You must specify how many cores to use per job "
-                             "with the cores= parameter")
+                             "like ``cores=8``")
+
+        if memory is None:
+            raise ValueError("You must specify how much memory to use per job "
+                             "like ``memory='24 GB'``")
 
         #This attribute should be overriden
         self.job_header = None

--- a/dask_jobqueue/core.py
+++ b/dask_jobqueue/core.py
@@ -4,7 +4,6 @@ import socket
 import subprocess
 import sys
 from contextlib import contextmanager
-import multiprocessing
 
 import dask
 import docrep
@@ -29,11 +28,11 @@ class JobQueueCluster(Cluster):
     name : str
         Name of Dask workers.
     cores : int
-        Total number of cores on a node / job
+        Total number of cores per job
     total_memory: str
-        Total amount of memory on a node / job
+        Total amount of memory per job
     processes : int
-        Number of processes per node.
+        Number of processes per job
     interface : str
         Network interface like 'eth0' or 'ib0'.
     death_timeout : float

--- a/dask_jobqueue/core.py
+++ b/dask_jobqueue/core.py
@@ -156,10 +156,7 @@ class JobQueueCluster(Cluster):
         self.cluster = LocalCluster(n_workers=0, ip=host, **kwargs)
 
         # Keep information on process, cores, and memory, for use in subclasses
-        if memory is not None:
-            self.worker_memory = parse_bytes(memory) / processes
-        else:
-            self.worker_memory = None
+        self.worker_memory = parse_bytes(memory)
 
         self.worker_processes = processes
         self.worker_cores = cores
@@ -178,7 +175,11 @@ class JobQueueCluster(Cluster):
         self._command_template += " --nthreads %d" % self.worker_threads
         if processes is not None and processes > 1:
             self._command_template += " --nprocs %d" % processes
-        self._command_template += " --memory-limit %s" % format_bytes(self.worker_memory).replace(' ', '')
+
+        mem = format_bytes(self.worker_memory / self.worker_processes)
+        mem = mem.replace(' ', '')
+        self._command_template += " --memory-limit %s" % mem
+
         if name is not None:
             self._command_template += " --name %s" % name
             self._command_template += "-%(n)d" # Keep %(n) to be replaced later

--- a/dask_jobqueue/jobqueue.yaml
+++ b/dask_jobqueue/jobqueue.yaml
@@ -3,12 +3,13 @@ jobqueue:
     name: dask-worker
 
     # Dask worker options
-    threads: 2
-    processes: 4
-    memory: 8GB
-    interface: null
-    death-timeout: 60
-    local-directory: null
+    cores: null                 # Total number of cores on a worker node
+    processes: 1                # Number of Python processes to cut up a worker node
+    total_memory: null          # Total amount of memory per worker node
+
+    interface: null             # Network interface to use like eth0 or ib0
+    death-timeout: 60           # Number of seconds to wait if a worker can not find a scheduler
+    local-directory: null       # Location of fast local storage like /scratch or $TMPDIR
 
     # PBS resource manager options
     queue: null
@@ -19,16 +20,20 @@ jobqueue:
     resource-spec: null
     job-extra: []
 
+    threads: null  # deprecated
+    memory: null  # deprecated
+
   sge:
     name: dask-worker
 
     # Dask worker options
-    threads: 2
-    processes: 4
-    memory: 8GB
-    interface: null
-    death-timeout: 60
-    local-directory: null
+    cores: null                 # Total number of cores on a worker node
+    processes: 1                # Number of Python processes to cut up a worker node
+    total_memory: null          # Total amount of memory per worker node
+
+    interface: null             # Network interface to use like eth0 or ib0
+    death-timeout: 60           # Number of seconds to wait if a worker can not find a scheduler
+    local-directory: null       # Location of fast local storage like /scratch or $TMPDIR
 
     # SGE resource manager options
     queue: null
@@ -39,16 +44,20 @@ jobqueue:
 
     resource-spec: null
 
+    threads: null  # deprecated
+    memory: null  # deprecated
+
   slurm:
     name: dask-worker
 
     # Dask worker options
-    threads: 2
-    processes: 4
-    memory: 8GB
-    interface: null
-    death-timeout: 60
-    local-directory: null
+    cores: null                 # Total number of cores on a worker node
+    processes: 1                # Number of Python processes to cut up a worker node
+    total_memory: null          # Total amount of memory per worker node
+
+    interface: null             # Network interface to use like eth0 or ib0
+    death-timeout: 60           # Number of seconds to wait if a worker can not find a scheduler
+    local-directory: null       # Location of fast local storage like /scratch or $TMPDIR
 
     # SLURM resource manager options
     queue: null
@@ -60,16 +69,20 @@ jobqueue:
     job-mem: null
     job-extra: {}
 
+    threads: null  # deprecated
+    memory: null  # deprecated
+
   moab:
     name: dask-worker
 
     # Dask worker options
-    threads: 2
-    processes: 4
-    memory: 8GB
-    interface: null
-    death-timeout: 60
-    local-directory: null
+    cores: null                 # Total number of cores on a worker node
+    processes: 1                # Number of Python processes to cut up a worker node
+    total_memory: null          # Total amount of memory per worker node
+
+    interface: null             # Network interface to use like eth0 or ib0
+    death-timeout: 60           # Number of seconds to wait if a worker can not find a scheduler
+    local-directory: null       # Location of fast local storage like /scratch or $TMPDIR
 
     # PBS resource manager options
     queue: null
@@ -79,3 +92,6 @@ jobqueue:
     env-extra: []
     resource-spec: null
     job-extra: []
+
+    threads: null  # deprecated
+    memory: null  # deprecated

--- a/dask_jobqueue/jobqueue.yaml
+++ b/dask_jobqueue/jobqueue.yaml
@@ -3,9 +3,9 @@ jobqueue:
     name: dask-worker
 
     # Dask worker options
-    cores: null                 # Total number of cores on a worker node
-    processes: 1                # Number of Python processes to cut up a worker node
-    total_memory: null          # Total amount of memory per worker node
+    cores: null                 # Total number of cores per job
+    processes: 1                # Number of Python processes per job
+    total_memory: null          # Total amount of memory per job
 
     interface: null             # Network interface to use like eth0 or ib0
     death-timeout: 60           # Number of seconds to wait if a worker can not find a scheduler
@@ -27,9 +27,9 @@ jobqueue:
     name: dask-worker
 
     # Dask worker options
-    cores: null                 # Total number of cores on a worker node
-    processes: 1                # Number of Python processes to cut up a worker node
-    total_memory: null          # Total amount of memory per worker node
+    cores: null                 # Total number of cores per job
+    processes: 1                # Number of Python processes per job
+    total_memory: null          # Total amount of memory per job
 
     interface: null             # Network interface to use like eth0 or ib0
     death-timeout: 60           # Number of seconds to wait if a worker can not find a scheduler
@@ -51,9 +51,9 @@ jobqueue:
     name: dask-worker
 
     # Dask worker options
-    cores: null                 # Total number of cores on a worker node
-    processes: 1                # Number of Python processes to cut up a worker node
-    total_memory: null          # Total amount of memory per worker node
+    cores: null                 # Total number of cores per job
+    processes: 1                # Number of Python processes per job
+    total_memory: null          # Total amount of memory per job
 
     interface: null             # Network interface to use like eth0 or ib0
     death-timeout: 60           # Number of seconds to wait if a worker can not find a scheduler
@@ -76,9 +76,9 @@ jobqueue:
     name: dask-worker
 
     # Dask worker options
-    cores: null                 # Total number of cores on a worker node
-    processes: 1                # Number of Python processes to cut up a worker node
-    total_memory: null          # Total amount of memory per worker node
+    cores: null                 # Total number of cores per job
+    processes: 1                # Number of Python processes per job
+    total_memory: null          # Total amount of memory per job
 
     interface: null             # Network interface to use like eth0 or ib0
     death-timeout: 60           # Number of seconds to wait if a worker can not find a scheduler

--- a/dask_jobqueue/jobqueue.yaml
+++ b/dask_jobqueue/jobqueue.yaml
@@ -4,8 +4,8 @@ jobqueue:
 
     # Dask worker options
     cores: null                 # Total number of cores per job
+    memory: null                # Total amount of memory per job
     processes: 1                # Number of Python processes per job
-    total_memory: null          # Total amount of memory per job
 
     interface: null             # Network interface to use like eth0 or ib0
     death-timeout: 60           # Number of seconds to wait if a worker can not find a scheduler
@@ -20,16 +20,13 @@ jobqueue:
     resource-spec: null
     job-extra: []
 
-    threads: null  # deprecated
-    memory: null  # deprecated
-
   sge:
     name: dask-worker
 
     # Dask worker options
     cores: null                 # Total number of cores per job
+    memory: null                # Total amount of memory per job
     processes: 1                # Number of Python processes per job
-    total_memory: null          # Total amount of memory per job
 
     interface: null             # Network interface to use like eth0 or ib0
     death-timeout: 60           # Number of seconds to wait if a worker can not find a scheduler
@@ -44,16 +41,13 @@ jobqueue:
 
     resource-spec: null
 
-    threads: null  # deprecated
-    memory: null  # deprecated
-
   slurm:
     name: dask-worker
 
     # Dask worker options
     cores: null                 # Total number of cores per job
+    memory: null                # Total amount of memory per job
     processes: 1                # Number of Python processes per job
-    total_memory: null          # Total amount of memory per job
 
     interface: null             # Network interface to use like eth0 or ib0
     death-timeout: 60           # Number of seconds to wait if a worker can not find a scheduler
@@ -69,16 +63,13 @@ jobqueue:
     job-mem: null
     job-extra: {}
 
-    threads: null  # deprecated
-    memory: null  # deprecated
-
   moab:
     name: dask-worker
 
     # Dask worker options
     cores: null                 # Total number of cores per job
+    memory: null                # Total amount of memory per job
     processes: 1                # Number of Python processes per job
-    total_memory: null          # Total amount of memory per job
 
     interface: null             # Network interface to use like eth0 or ib0
     death-timeout: 60           # Number of seconds to wait if a worker can not find a scheduler
@@ -92,6 +83,3 @@ jobqueue:
     env-extra: []
     resource-spec: null
     job-extra: []
-
-    threads: null  # deprecated
-    memory: null  # deprecated

--- a/dask_jobqueue/pbs.py
+++ b/dask_jobqueue/pbs.py
@@ -86,10 +86,8 @@ class PBSCluster(JobQueueCluster):
         if resource_spec is None:
             # Compute default resources specifications
             resource_spec = "select=1:ncpus=%d" % self.worker_cores
-            if self.worker_memory:
-                memory = self.worker_memory * self.worker_processes
-                memory_string = pbs_format_bytes_ceil(memory)
-                resource_spec += ':mem=' + memory_string
+            memory_string = pbs_format_bytes_ceil(self.worker_memory)
+            resource_spec += ':mem=' + memory_string
             logger.info("Resource specification for PBS not set, "
                         "initializing it to %s" % resource_spec)
         if resource_spec is not None:

--- a/dask_jobqueue/pbs.py
+++ b/dask_jobqueue/pbs.py
@@ -83,10 +83,9 @@ class PBSCluster(JobQueueCluster):
             header_lines.append('#PBS -q %s' % queue)
         if project is not None:
             header_lines.append('#PBS -A %s' % project)
-        if resource_spec is None and self.worker_threads:
+        if resource_spec is None:
             # Compute default resources specifications
-            ncpus = self.worker_processes * self.worker_threads
-            resource_spec = "select=1:ncpus=%d" % ncpus
+            resource_spec = "select=1:ncpus=%d" % self.worker_cores
             if self.worker_memory:
                 memory = self.worker_memory * self.worker_processes
                 memory_string = pbs_format_bytes_ceil(memory)

--- a/dask_jobqueue/pbs.py
+++ b/dask_jobqueue/pbs.py
@@ -83,12 +83,14 @@ class PBSCluster(JobQueueCluster):
             header_lines.append('#PBS -q %s' % queue)
         if project is not None:
             header_lines.append('#PBS -A %s' % project)
-        if resource_spec is None and self.worker_processes and self.worker_threads:
+        if resource_spec is None and self.worker_threads:
             # Compute default resources specifications
             ncpus = self.worker_processes * self.worker_threads
-            memory = self.worker_memory * self.worker_processes
-            memory_string = pbs_format_bytes_ceil(memory)
-            resource_spec = "select=1:ncpus=%d:mem=%s" % (ncpus, memory_string)
+            resource_spec = "select=1:ncpus=%d" % ncpus
+            if self.worker_memory:
+                memory = self.worker_memory * self.worker_processes
+                memory_string = pbs_format_bytes_ceil(memory)
+                resource_spec += ':mem=' + memory_string
             logger.info("Resource specification for PBS not set, "
                         "initializing it to %s" % resource_spec)
         if resource_spec is not None:

--- a/dask_jobqueue/pbs.py
+++ b/dask_jobqueue/pbs.py
@@ -83,7 +83,7 @@ class PBSCluster(JobQueueCluster):
             header_lines.append('#PBS -q %s' % queue)
         if project is not None:
             header_lines.append('#PBS -A %s' % project)
-        if resource_spec is None:
+        if resource_spec is None and self.worker_processes and self.worker_threads:
             # Compute default resources specifications
             ncpus = self.worker_processes * self.worker_threads
             memory = self.worker_memory * self.worker_processes
@@ -91,7 +91,8 @@ class PBSCluster(JobQueueCluster):
             resource_spec = "select=1:ncpus=%d:mem=%s" % (ncpus, memory_string)
             logger.info("Resource specification for PBS not set, "
                         "initializing it to %s" % resource_spec)
-        header_lines.append('#PBS -l %s' % resource_spec)
+        if resource_spec is not None:
+            header_lines.append('#PBS -l %s' % resource_spec)
         if walltime is not None:
             header_lines.append('#PBS -l walltime=%s' % walltime)
         header_lines.extend(['#PBS %s' % arg for arg in job_extra])

--- a/dask_jobqueue/slurm.py
+++ b/dask_jobqueue/slurm.py
@@ -91,9 +91,8 @@ class SLURMCluster(JobQueueCluster):
         header_lines.append('#SBATCH --cpus-per-task=%d' % (job_cpu or self.worker_cores))
         # Memory
         memory = job_mem
-        if job_mem is None and self.worker_memory is not None:
-            memory = self.worker_processes * self.worker_memory
-            memory = slurm_format_bytes_ceil(memory)
+        if job_mem is None:
+            memory = slurm_format_bytes_ceil(self.worker_memory)
         if memory is not None:
             header_lines.append('#SBATCH --mem=%s' % memory)
 

--- a/dask_jobqueue/slurm.py
+++ b/dask_jobqueue/slurm.py
@@ -94,12 +94,12 @@ class SLURMCluster(JobQueueCluster):
         if ncpus is not None:
             header_lines.append('#SBATCH --cpus-per-task=%d' % ncpus)
         # Memory
-        total_memory = job_mem
+        memory = job_mem
         if job_mem is None and self.worker_memory is not None:
             memory = self.worker_processes * self.worker_memory
-            total_memory = slurm_format_bytes_ceil(memory)
-        if total_memory is not None:
-            header_lines.append('#SBATCH --mem=%s' % total_memory)
+            memory = slurm_format_bytes_ceil(memory)
+        if memory is not None:
+            header_lines.append('#SBATCH --mem=%s' % memory)
 
         if walltime is not None:
             header_lines.append('#SBATCH -t %s' % walltime)

--- a/dask_jobqueue/slurm.py
+++ b/dask_jobqueue/slurm.py
@@ -88,11 +88,7 @@ class SLURMCluster(JobQueueCluster):
         # Init resources, always 1 task,
         # and then number of cpu is processes * threads if not set
         header_lines.append('#SBATCH -n 1')
-        ncpus = job_cpu
-        if ncpus is None and self.worker_processes and self.worker_threads:
-            ncpus = self.worker_processes * self.worker_threads
-        if ncpus is not None:
-            header_lines.append('#SBATCH --cpus-per-task=%d' % ncpus)
+        header_lines.append('#SBATCH --cpus-per-task=%d' % (job_cpu or self.worker_cores))
         # Memory
         memory = job_mem
         if job_mem is None and self.worker_memory is not None:

--- a/dask_jobqueue/slurm.py
+++ b/dask_jobqueue/slurm.py
@@ -89,9 +89,10 @@ class SLURMCluster(JobQueueCluster):
         # and then number of cpu is processes * threads if not set
         header_lines.append('#SBATCH -n 1')
         ncpus = job_cpu
-        if ncpus is None:
+        if ncpus is None and self.worker_processes and self.worker_threads:
             ncpus = self.worker_processes * self.worker_threads
-        header_lines.append('#SBATCH --cpus-per-task=%d' % ncpus)
+        if ncpus is not None:
+            header_lines.append('#SBATCH --cpus-per-task=%d' % ncpus)
         # Memory
         total_memory = job_mem
         if job_mem is None and self.worker_memory is not None:

--- a/dask_jobqueue/tests/test_jobqueue_core.py
+++ b/dask_jobqueue/tests/test_jobqueue_core.py
@@ -13,3 +13,11 @@ def test_errors():
         JobQueueCluster(cores=4)
 
     assert 'abstract class' in str(info.value)
+
+
+def test_threads_deprecation():
+    with pytest.raises(ValueError) as info:
+        JobQueueCluster(threads=4)
+
+    assert all(word in str(info.value)
+               for word in ['threads', 'core', 'processes'])

--- a/dask_jobqueue/tests/test_jobqueue_core.py
+++ b/dask_jobqueue/tests/test_jobqueue_core.py
@@ -10,6 +10,6 @@ def test_jq_core_placeholder():
 
 def test_errors():
     with pytest.raises(NotImplementedError) as info:
-        JobQueueCluster()
+        JobQueueCluster(cores=4)
 
     assert 'abstract class' in str(info.value)

--- a/dask_jobqueue/tests/test_pbs.py
+++ b/dask_jobqueue/tests/test_pbs.py
@@ -30,7 +30,7 @@ def test_header(Cluster):
         assert '#PBS -l walltime=' in cluster.job_header
         assert '#PBS -A DaskOnPBS' in cluster.job_header
 
-    with Cluster(cores=4) as cluster:
+    with Cluster(cores=4, memory='8GB') as cluster:
 
         assert '#PBS -j oe' not in cluster.job_header
         assert '#PBS -N' in cluster.job_header
@@ -39,7 +39,7 @@ def test_header(Cluster):
         assert '#PBS -A' not in cluster.job_header
         assert '#PBS -q' not in cluster.job_header
 
-    with Cluster(cores=4, job_extra=['-j oe']) as cluster:
+    with Cluster(cores=4, memory='8GB', job_extra=['-j oe']) as cluster:
 
         assert '#PBS -j oe' in cluster.job_header
         assert '#PBS -N' in cluster.job_header
@@ -139,6 +139,16 @@ def test_adaptive(loop):
 def test_config(loop):  # noqa: F811
     with dask.config.set({'jobqueue.pbs.walltime': '00:02:00',
                           'jobqueue.pbs.local-directory': '/foo'}):
-        with PBSCluster(loop=loop, cores=1) as cluster:
+        with PBSCluster(loop=loop, cores=1, memory='2GB') as cluster:
             assert '00:02:00' in cluster.job_script()
             assert '--local-directory /foo' in cluster.job_script()
+
+
+def test_informative_errors():
+    with pytest.raises(ValueError) as info:
+        PBSCluster(memory=None, cores=4)
+    assert 'memory' in str(info.value)
+
+    with pytest.raises(ValueError) as info:
+        PBSCluster(memory='1GB', cores=None)
+    assert 'cores' in str(info.value)

--- a/dask_jobqueue/tests/test_pbs.py
+++ b/dask_jobqueue/tests/test_pbs.py
@@ -56,7 +56,6 @@ def test_job_script(Cluster):
         job_script = cluster.job_script()
         assert '#PBS' in job_script
         assert '#PBS -N dask-worker' in job_script
-        assert '--nthreads 2' in job_script
         assert '#PBS -l select=1:ncpus=8:mem=27GB' in job_script
         assert '#PBS -l walltime=00:02:00' in job_script
         assert '#PBS -q' not in job_script

--- a/dask_jobqueue/tests/test_pbs.py
+++ b/dask_jobqueue/tests/test_pbs.py
@@ -11,7 +11,7 @@ from dask_jobqueue import PBSCluster, MoabCluster
 
 @pytest.mark.parametrize('Cluster', [PBSCluster, MoabCluster])
 def test_header(Cluster):
-    with Cluster(walltime='00:02:00', processes=4, threads=2, memory='7GB') as cluster:
+    with Cluster(walltime='00:02:00', processes=4, cores=8, total_memory='28GB') as cluster:
 
         assert '#PBS' in cluster.job_header
         assert '#PBS -N dask-worker' in cluster.job_header
@@ -34,7 +34,7 @@ def test_header(Cluster):
 
         assert '#PBS -j oe' not in cluster.job_header
         assert '#PBS -N' in cluster.job_header
-        assert '#PBS -l select=1:ncpus=' in cluster.job_header
+        # assert '#PBS -l select=1:ncpus=' in cluster.job_header
         assert '#PBS -l walltime=' in cluster.job_header
         assert '#PBS -A' not in cluster.job_header
         assert '#PBS -q' not in cluster.job_header
@@ -43,7 +43,7 @@ def test_header(Cluster):
 
         assert '#PBS -j oe' in cluster.job_header
         assert '#PBS -N' in cluster.job_header
-        assert '#PBS -l select=1:ncpus=' in cluster.job_header
+        # assert '#PBS -l select=1:ncpus=' in cluster.job_header
         assert '#PBS -l walltime=' in cluster.job_header
         assert '#PBS -A' not in cluster.job_header
         assert '#PBS -q' not in cluster.job_header
@@ -51,18 +51,19 @@ def test_header(Cluster):
 
 @pytest.mark.parametrize('Cluster', [PBSCluster, MoabCluster])
 def test_job_script(Cluster):
-    with Cluster(walltime='00:02:00', processes=4, threads=2, memory='7GB') as cluster:
+    with Cluster(walltime='00:02:00', processes=4, cores=8, total_memory='28GB') as cluster:
 
         job_script = cluster.job_script()
         assert '#PBS' in job_script
         assert '#PBS -N dask-worker' in job_script
+        assert '--nthreads 2' in job_script
         assert '#PBS -l select=1:ncpus=8:mem=27GB' in job_script
         assert '#PBS -l walltime=00:02:00' in job_script
         assert '#PBS -q' not in job_script
         assert '#PBS -A' not in job_script
 
         assert '{} -m distributed.cli.dask_worker tcp://'.format(sys.executable) in job_script
-        assert '--nthreads 2 --nprocs 4 --memory-limit 7GB' in job_script
+        assert '--nthreads 2 --nprocs 4 --memory-limit 7.00GB' in job_script
 
     with Cluster(queue='regular', project='DaskOnPBS', processes=4, threads=2, memory='7GB',
                  resource_spec='select=1:ncpus=24:mem=100GB') as cluster:
@@ -76,7 +77,7 @@ def test_job_script(Cluster):
         assert '#PBS -A DaskOnPBS' in job_script
 
         assert '{} -m distributed.cli.dask_worker tcp://'.format(sys.executable) in job_script
-        assert '--nthreads 2 --nprocs 4 --memory-limit 7GB' in job_script
+        assert '--nthreads 2 --nprocs 4 --memory-limit 7.00GB' in job_script
 
 
 @pytest.mark.env("pbs")  # noqa: F811

--- a/dask_jobqueue/tests/test_pbs.py
+++ b/dask_jobqueue/tests/test_pbs.py
@@ -11,7 +11,7 @@ from dask_jobqueue import PBSCluster, MoabCluster
 
 @pytest.mark.parametrize('Cluster', [PBSCluster, MoabCluster])
 def test_header(Cluster):
-    with Cluster(walltime='00:02:00', processes=4, cores=8, total_memory='28GB') as cluster:
+    with Cluster(walltime='00:02:00', processes=4, cores=8, memory='28GB') as cluster:
 
         assert '#PBS' in cluster.job_header
         assert '#PBS -N dask-worker' in cluster.job_header
@@ -20,8 +20,8 @@ def test_header(Cluster):
         assert '#PBS -q' not in cluster.job_header
         assert '#PBS -A' not in cluster.job_header
 
-    with Cluster(queue='regular', project='DaskOnPBS', processes=4, threads=2, memory='7GB',
-                 resource_spec='select=1:ncpus=24:mem=100GB') as cluster:
+    with Cluster(queue='regular', project='DaskOnPBS', processes=4, cores=8,
+                 memory='28GB', resource_spec='select=1:ncpus=24:mem=100GB') as cluster:
 
         assert '#PBS -q regular' in cluster.job_header
         assert '#PBS -N dask-worker' in cluster.job_header
@@ -30,7 +30,7 @@ def test_header(Cluster):
         assert '#PBS -l walltime=' in cluster.job_header
         assert '#PBS -A DaskOnPBS' in cluster.job_header
 
-    with Cluster() as cluster:
+    with Cluster(cores=4) as cluster:
 
         assert '#PBS -j oe' not in cluster.job_header
         assert '#PBS -N' in cluster.job_header
@@ -39,7 +39,7 @@ def test_header(Cluster):
         assert '#PBS -A' not in cluster.job_header
         assert '#PBS -q' not in cluster.job_header
 
-    with Cluster(job_extra=['-j oe']) as cluster:
+    with Cluster(cores=4, job_extra=['-j oe']) as cluster:
 
         assert '#PBS -j oe' in cluster.job_header
         assert '#PBS -N' in cluster.job_header
@@ -51,7 +51,7 @@ def test_header(Cluster):
 
 @pytest.mark.parametrize('Cluster', [PBSCluster, MoabCluster])
 def test_job_script(Cluster):
-    with Cluster(walltime='00:02:00', processes=4, cores=8, total_memory='28GB') as cluster:
+    with Cluster(walltime='00:02:00', processes=4, cores=8, memory='28GB') as cluster:
 
         job_script = cluster.job_script()
         assert '#PBS' in job_script
@@ -64,8 +64,8 @@ def test_job_script(Cluster):
         assert '{} -m distributed.cli.dask_worker tcp://'.format(sys.executable) in job_script
         assert '--nthreads 2 --nprocs 4 --memory-limit 7.00GB' in job_script
 
-    with Cluster(queue='regular', project='DaskOnPBS', processes=4, threads=2, memory='7GB',
-                 resource_spec='select=1:ncpus=24:mem=100GB') as cluster:
+    with Cluster(queue='regular', project='DaskOnPBS', processes=4, cores=8,
+                 memory='28GB', resource_spec='select=1:ncpus=24:mem=100GB') as cluster:
 
         job_script = cluster.job_script()
         assert '#PBS -q regular' in job_script
@@ -81,7 +81,7 @@ def test_job_script(Cluster):
 
 @pytest.mark.env("pbs")  # noqa: F811
 def test_basic(loop):
-    with PBSCluster(walltime='00:02:00', processes=1, threads=2, memory='2GB', local_directory='/tmp',
+    with PBSCluster(walltime='00:02:00', processes=1, cores=2, memory='2GB', local_directory='/tmp',
                     job_extra=['-V'], loop=loop) as cluster:
         with Client(cluster) as client:
             workers = cluster.start_workers(2)
@@ -106,7 +106,7 @@ def test_basic(loop):
 
 @pytest.mark.env("pbs")  # noqa: F811
 def test_adaptive(loop):
-    with PBSCluster(walltime='00:02:00', processes=1, threads=2, memory='2GB', local_directory='/tmp',
+    with PBSCluster(walltime='00:02:00', processes=1, cores=2, memory='2GB', local_directory='/tmp',
                     job_extra=['-V'], loop=loop) as cluster:
         cluster.adapt()
         with Client(cluster) as client:
@@ -139,6 +139,6 @@ def test_adaptive(loop):
 def test_config(loop):  # noqa: F811
     with dask.config.set({'jobqueue.pbs.walltime': '00:02:00',
                           'jobqueue.pbs.local-directory': '/foo'}):
-        with PBSCluster(loop=loop) as cluster:
+        with PBSCluster(loop=loop, cores=1) as cluster:
             assert '00:02:00' in cluster.job_script()
             assert '--local-directory /foo' in cluster.job_script()

--- a/dask_jobqueue/tests/test_sge.py
+++ b/dask_jobqueue/tests/test_sge.py
@@ -10,7 +10,7 @@ pytestmark = pytest.mark.env("sge")
 
 
 def test_basic(loop):  # noqa: F811
-    with SGECluster(walltime='00:02:00', cores=8, processes=4, total_memory='28GB',
+    with SGECluster(walltime='00:02:00', cores=8, processes=4, memory='28GB',
                     loop=loop) as cluster:
         with Client(cluster, loop=loop) as client:
             workers = cluster.start_workers(2)

--- a/dask_jobqueue/tests/test_sge.py
+++ b/dask_jobqueue/tests/test_sge.py
@@ -10,7 +10,7 @@ pytestmark = pytest.mark.env("sge")
 
 
 def test_basic(loop):  # noqa: F811
-    with SGECluster(walltime='00:02:00', threads=2, memory='7GB',
+    with SGECluster(walltime='00:02:00', cores=8, processes=4, total_memory='28GB',
                     loop=loop) as cluster:
         with Client(cluster, loop=loop) as client:
             workers = cluster.start_workers(2)
@@ -19,9 +19,9 @@ def test_basic(loop):  # noqa: F811
             assert cluster.jobs
 
             info = client.scheduler_info()
-            w = list(info['workers'].values())[0]
-            assert w['memory_limit'] == 7e9
-            assert w['ncores'] == 2
+            for w in info['workers'].values():
+                assert w['memory_limit'] == 7e9
+                assert w['ncores'] == 2
 
             cluster.stop_workers(workers)
 

--- a/dask_jobqueue/tests/test_slurm.py
+++ b/dask_jobqueue/tests/test_slurm.py
@@ -9,7 +9,7 @@ from dask_jobqueue import SLURMCluster
 
 
 def test_header():
-    with SLURMCluster(walltime='00:02:00', processes=4, threads=2, memory='7GB') as cluster:
+    with SLURMCluster(walltime='00:02:00', processes=4, cores=8, total_memory='28GB') as cluster:
 
         assert '#SBATCH' in cluster.job_header
         assert '#SBATCH -J dask-worker' in cluster.job_header
@@ -35,19 +35,22 @@ def test_header():
         assert '#SBATCH' in cluster.job_header
         assert '#SBATCH -J ' in cluster.job_header
         assert '#SBATCH -n 1' in cluster.job_header
-        assert '#SBATCH --cpus-per-task=' in cluster.job_header
-        assert '#SBATCH --mem=' in cluster.job_header
+        # assert '#SBATCH --cpus-per-task=' in cluster.job_header
+        # assert '#SBATCH --mem=' in cluster.job_header
         assert '#SBATCH -t ' in cluster.job_header
         assert '#SBATCH -p' not in cluster.job_header
         assert '#SBATCH -A' not in cluster.job_header
 
 
 def test_job_script():
-    with SLURMCluster(walltime='00:02:00', processes=4, threads=2, memory='7GB') as cluster:
+    with SLURMCluster(walltime='00:02:00', processes=4, cores=8,
+                      total_memory='28GB') as cluster:
 
         job_script = cluster.job_script()
         assert '#SBATCH' in job_script
         assert '#SBATCH -J dask-worker' in job_script
+        assert '--nthreads 2 ' in job_script
+        assert '--memory-limit 7.00GB ' in job_script
         assert '#SBATCH -n 1' in job_script
         assert '#SBATCH --cpus-per-task=8' in job_script
         assert '#SBATCH --mem=27G' in job_script
@@ -58,7 +61,7 @@ def test_job_script():
         assert 'export ' not in job_script
 
         assert '{} -m distributed.cli.dask_worker tcp://'.format(sys.executable) in job_script
-        assert '--nthreads 2 --nprocs 4 --memory-limit 7GB' in job_script
+        assert '--nthreads 2 --nprocs 4 --memory-limit 7.00GB' in job_script
 
     with SLURMCluster(walltime='00:02:00', processes=4, threads=2, memory='7GB',
                       env_extra=['export LANG="en_US.utf8"', 'export LANGUAGE="en_US.utf8"',
@@ -79,7 +82,7 @@ def test_job_script():
         assert 'export LC_ALL="en_US.utf8"' in job_script
 
         assert '{} -m distributed.cli.dask_worker tcp://'.format(sys.executable) in job_script
-        assert '--nthreads 2 --nprocs 4 --memory-limit 7GB' in job_script
+        assert '--nthreads 2 --nprocs 4 --memory-limit 7.00GB' in job_script
 
 
 @pytest.mark.env("slurm")  # noqa: F811

--- a/dask_jobqueue/tests/test_slurm.py
+++ b/dask_jobqueue/tests/test_slurm.py
@@ -9,7 +9,7 @@ from dask_jobqueue import SLURMCluster
 
 
 def test_header():
-    with SLURMCluster(walltime='00:02:00', processes=4, cores=8, total_memory='28GB') as cluster:
+    with SLURMCluster(walltime='00:02:00', processes=4, cores=8, memory='28GB') as cluster:
 
         assert '#SBATCH' in cluster.job_header
         assert '#SBATCH -J dask-worker' in cluster.job_header
@@ -20,8 +20,8 @@ def test_header():
         assert '#SBATCH -p' not in cluster.job_header
         assert '#SBATCH -A' not in cluster.job_header
 
-    with SLURMCluster(queue='regular', project='DaskOnPBS', processes=4, threads=2, memory='7GB',
-                      job_cpu=16, job_mem='100G') as cluster:
+    with SLURMCluster(queue='regular', project='DaskOnPBS', processes=4,
+                      cores=8, memory='28GB', job_cpu=16, job_mem='100G') as cluster:
 
         assert '#SBATCH --cpus-per-task=16' in cluster.job_header
         assert '#SBATCH --cpus-per-task=8' not in cluster.job_header
@@ -30,7 +30,7 @@ def test_header():
         assert '#SBATCH -A DaskOnPBS' in cluster.job_header
         assert '#SBATCH -p regular' in cluster.job_header
 
-    with SLURMCluster() as cluster:
+    with SLURMCluster(cores=4) as cluster:
 
         assert '#SBATCH' in cluster.job_header
         assert '#SBATCH -J ' in cluster.job_header
@@ -44,7 +44,7 @@ def test_header():
 
 def test_job_script():
     with SLURMCluster(walltime='00:02:00', processes=4, cores=8,
-                      total_memory='28GB') as cluster:
+                      memory='28GB') as cluster:
 
         job_script = cluster.job_script()
         assert '#SBATCH' in job_script
@@ -62,7 +62,7 @@ def test_job_script():
         assert '{} -m distributed.cli.dask_worker tcp://'.format(sys.executable) in job_script
         assert '--nthreads 2 --nprocs 4 --memory-limit 7.00GB' in job_script
 
-    with SLURMCluster(walltime='00:02:00', processes=4, threads=2, memory='7GB',
+    with SLURMCluster(walltime='00:02:00', processes=4, cores=8, memory='28GB',
                       env_extra=['export LANG="en_US.utf8"', 'export LANGUAGE="en_US.utf8"',
                                  'export LC_ALL="en_US.utf8"']
                       ) as cluster:
@@ -86,7 +86,7 @@ def test_job_script():
 
 @pytest.mark.env("slurm")  # noqa: F811
 def test_basic(loop):
-    with SLURMCluster(walltime='00:02:00', threads=2, processes=1, memory='4GB',
+    with SLURMCluster(walltime='00:02:00', cores=2, processes=1, memory='4GB',
                       job_extra=['-D /'], loop=loop) as cluster:
         with Client(cluster) as client:
             workers = cluster.start_workers(2)
@@ -111,7 +111,7 @@ def test_basic(loop):
 
 @pytest.mark.env("slurm")  # noqa: F811
 def test_adaptive(loop):
-    with SLURMCluster(walltime='00:02:00', threads=2, processes=1, memory='4GB',
+    with SLURMCluster(walltime='00:02:00', cores=2, processes=1, memory='4GB',
                       job_extra=['-D /'], loop=loop) as cluster:
         cluster.adapt()
         with Client(cluster) as client:

--- a/dask_jobqueue/tests/test_slurm.py
+++ b/dask_jobqueue/tests/test_slurm.py
@@ -30,7 +30,7 @@ def test_header():
         assert '#SBATCH -A DaskOnPBS' in cluster.job_header
         assert '#SBATCH -p regular' in cluster.job_header
 
-    with SLURMCluster(cores=4) as cluster:
+    with SLURMCluster(cores=4, memory='8GB') as cluster:
 
         assert '#SBATCH' in cluster.job_header
         assert '#SBATCH -J ' in cluster.job_header

--- a/dask_jobqueue/tests/test_slurm.py
+++ b/dask_jobqueue/tests/test_slurm.py
@@ -49,7 +49,6 @@ def test_job_script():
         job_script = cluster.job_script()
         assert '#SBATCH' in job_script
         assert '#SBATCH -J dask-worker' in job_script
-        assert '--nthreads 2 ' in job_script
         assert '--memory-limit 7.00GB ' in job_script
         assert '#SBATCH -n 1' in job_script
         assert '#SBATCH --cpus-per-task=8' in job_script

--- a/docs/configurations.rst
+++ b/docs/configurations.rst
@@ -1,0 +1,42 @@
+Configuration Examples
+======================
+
+We include configuration files for known supercomputers.
+Hopefully these help both other users that use those machines and new users who
+want to see examples for similar clusters.
+
+Additional examples from other cluster welcome `here <https://github.com/dask/dask-jobqueue/issues/40>`_.
+
+Cheynne
+-------
+
+`Cheyenne Supercomputer <https://www2.cisl.ucar.edu/resources/computational-systems/cheyenne>`_
+
+.. code-block:: yaml
+
+   distributed:
+     scheduler:
+       bandwidth: 1000000000     # GB MB/s estimated worker-worker bandwidth
+     worker:
+       memory:
+         target: 0.90  # Avoid spilling to disk
+         spill: False  # Avoid spilling to disk
+         pause: 0.80  # fraction at which we pause worker threads
+         terminate: 0.95  # fraction at which we terminate the worker
+     comm:
+       compression: null
+
+   jobqueue:
+     pbs:
+       cores: 36
+       processes: 4
+       total-memory: 108GB
+       interface: ib0
+       local-directory: $TMPDIR
+
+       queue: regular
+       project: null  # TODO, change me
+       walltime: '00:30:00'
+
+       resource-spec: select=1:ncpus=36:mem=109G
+

--- a/docs/configurations.rst
+++ b/docs/configurations.rst
@@ -7,8 +7,8 @@ want to see examples for similar clusters.
 
 Additional examples from other cluster welcome `here <https://github.com/dask/dask-jobqueue/issues/40>`_.
 
-Cheynne
--------
+Cheyenne
+--------
 
 `Cheyenne Supercomputer <https://www2.cisl.ucar.edu/resources/computational-systems/cheyenne>`_
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -17,12 +17,12 @@ Example
 
    from dask_jobqueue import PBSCluster
    cluster = PBSCluster()
-   cluster.scale(10)         # Ask for ten worker nodes
-
-   # wait for jobs to arrive, depending on the queue, this may take some time
+   cluster.scale(10)         # Ask for ten jobs
 
    from dask.distributed import Client
-   client = Client(cluster)  # Connect Dask to the worker nodes
+   client = Client(cluster)  # Connect this local process to remote workers
+
+   # wait for jobs to arrive, depending on the queue, this may take some time
 
    import dask.array as da
    x = ...                   # Dask commands now use these distributed resources
@@ -44,7 +44,7 @@ Configuration
 -------------
 
 Dask-jobqueue should be configured to your cluster so that it knows how many
-resources to request of each node and how to break up those resources.  You can
+resources to request of each job and how to break up those resources.  You can
 specify configuration either with keyword arguments when creating a ``Cluster``
 object, or with a configuration file.
 
@@ -52,15 +52,15 @@ Keyword Arguments
 ~~~~~~~~~~~~~~~~~
 
 You can pass keywords to the Cluster objects to define how Dask-jobqueue should
-cut up a *single* worker node:
+define a single job:
 
 .. code-block:: python
 
    cluster = PBSCluster(
         # Dask-worker specific keywords
-        cores=24,             # Number of cores per worker-node
-        total_memory='100GB', # Amount of memory per worker-node
-        processes=6,          # Number of Python processes by which to cut up each worker node
+        cores=24,             # Number of cores per job
+        total_memory='100GB', # Amount of memory per job
+        processes=6,          # Number of Python processes to cut up each job
         local_directory='$TMPDIR',  # Location to put temporary data if necessary
         # Job scheduler specific keywords
         resource_spec='select=1:ncpus=24:mem=100GB',
@@ -70,13 +70,13 @@ cut up a *single* worker node:
    )
 
 Note that the cores and total_memory keywords above correspond not to your
-full desired deployment, but rather to the size of a *single worker node*.
-Separately you will specify how many worker nodes you want using the scale
-method.
+full desired deployment, but rather to the size of a *single job* which should
+be no larger than the size of a single machine in your cluster.  Separately you
+will specify how many jobs to deploy using the scale method.
 
 .. code-block:: python
 
-   cluster.scale(20)  # ask for twenty nodes of the specification provided above
+   cluster.scale(20)  # launch twenty jobs of the specification provided above
 
 Configuration Files
 ~~~~~~~~~~~~~~~~~~~

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -27,8 +27,6 @@ Example
    import dask.array as da
    x = ...                   # Dask commands now use these distributed resources
 
-See :doc:`Examples <examples>` for more real-world examples.
-
 
 Adaptivity
 ----------
@@ -68,6 +66,7 @@ cut up a *single* worker node:
         resource_spec='select=1:ncpus=24:mem=100GB',
         queue='regular',
         project='my-project',
+        walltime='02:00:00',
    )
 
 Note that the cores and total_memory keywords above correspond not to your
@@ -77,7 +76,7 @@ method.
 
 .. code-block:: python
 
-   cluster.scale(20)  # ask for twenty nodes
+   cluster.scale(20)  # ask for twenty nodes of the specification provided above
 
 Configuration Files
 ~~~~~~~~~~~~~~~~~~~
@@ -99,16 +98,19 @@ recommend using a configuration file like the following:
        resource-spec: "select=1:ncpus=24:mem=100GB"
        queue: regular
        project: my-project
+       walltime: 02:00:00
+
+See :doc:`Configuration Examples <configurations>` for real-world examples.
 
 If you place this in your ``~/.config/dask/`` directory then Dask-jobqueue will
-use these values by default.  You can then construct a cluster object more
-simply.
+use these values by default.  You can then construct a cluster object without
+keyword arguments and these parameters will be used by default.
 
 .. code-block:: python
 
    cluster = PBSCluster()
 
-If you want you can still override configuration values with keyword arguments
+You can still override configuration values with keyword arguments
 
 .. code-block:: python
 
@@ -120,7 +122,7 @@ section of that configuation file that corresponds to your job scheduler.
 Above we used PBS, but other job schedulers operate the same way.  You should
 be able to share these with colleagues.  If you can convince your IT staff
 you can also place such a file in ``/etc/dask/`` and it will affect all people
-on the cluster.
+on the cluster automatically.
 
 For more information about configuring Dask, see the `Dask configuration
 documentation <http://dask.pydata.org/en/latest/configuration.html>`_
@@ -130,8 +132,9 @@ documentation <http://dask.pydata.org/en/latest/configuration.html>`_
    :maxdepth: 1
    :hidden:
 
+   index.rst
    install.rst
-   examples.rst
+   configurations.rst
    history.rst
    api.rst
 
@@ -144,13 +147,14 @@ object is instantiated:
 .. code-block:: python
 
    cluster = PBSCluster(  # <-- scheduler started here
-        processes=18,
-        threads=4,
-        memory="6GB",
-        project='P48500028',
-        queue='premium',
-        resource_spec='select=1:ncpus=36:mem=109G',
-        walltime='02:00:00'
+        cores=24,
+        total_memory='100GB',
+        processes=6,
+        local_directory='$TMPDIR',
+        resource_spec='select=1:ncpus=24:mem=100GB',
+        queue='regular',
+        project='my-project',
+        walltime='02:00:00',
    )
 
 You then ask for more workers using the ``scale`` command:
@@ -172,13 +176,13 @@ generate as follows:
    #!/bin/bash
 
    #PBS -N dask-worker
-   #PBS -q premium
+   #PBS -q regular
    #PBS -A P48500028
-   #PBS -l select=1:ncpus=36:mem=109G
+   #PBS -l select=1:ncpus=24:mem=100G
    #PBS -l walltime=02:00:00
 
    /home/mrocklin/Software/anaconda/bin/dask-worker tcp://127.0.1.1:43745
-   --nthreads 4 --nprocs 18 --memory-limit 6GB --name dask-worker-3
+   --nthreads 4 --nprocs 6 --memory-limit 18.66GB --name dask-worker-3
    --death-timeout 60
 
 Each of these jobs are sent to the job queue independently and, once that job

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -43,7 +43,7 @@ save resources when not actively computing.
 Configuration
 -------------
 
-Dask-jobqueue should be configured to your cluster so that it knows how many
+Dask-jobqueue should be configured for your cluster so that it knows how many
 resources to request of each job and how to break up those resources.  You can
 specify configuration either with keyword arguments when creating a ``Cluster``
 object, or with a configuration file.
@@ -59,7 +59,7 @@ define a single job:
    cluster = PBSCluster(
         # Dask-worker specific keywords
         cores=24,             # Number of cores per job
-        total_memory='100GB', # Amount of memory per job
+        memory='100GB',       # Amount of memory per job
         processes=6,          # Number of Python processes to cut up each job
         local_directory='$TMPDIR',  # Location to put temporary data if necessary
         # Job scheduler specific keywords
@@ -69,7 +69,7 @@ define a single job:
         walltime='02:00:00',
    )
 
-Note that the cores and total_memory keywords above correspond not to your
+Note that the ``cores`` and ``memory`` keywords above correspond not to your
 full desired deployment, but rather to the size of a *single job* which should
 be no larger than the size of a single machine in your cluster.  Separately you
 will specify how many jobs to deploy using the scale method.
@@ -148,7 +148,7 @@ object is instantiated:
 
    cluster = PBSCluster(  # <-- scheduler started here
         cores=24,
-        total_memory='100GB',
+        memory='100GB',
         processes=6,
         local_directory='$TMPDIR',
         resource_spec='select=1:ncpus=24:mem=100GB',


### PR DESCRIPTION
These overlap with (and might possibly replace) the threads and memory
parameters.  I believe that they are more consistent with typcial use.

Now we ask people to specify the cores and total memory of a node.  This
should remain relatively static over time.  Then we allow them to tune
processes as they like independently of other parameters.

### Example

```python
# Before
cluster = PBSCluster(threads=4, processes=9, memory='10GB')
cluster = PBSCluster(threads=12, processes=3, memory='30GB')
```
```python
# After
cluster = PBSCluster(cores=36, total_memory='90GB', processes=9)
cluster = PBSCluster(cores=36, total_memory='90GB', processes=3)
# or just
cluster = PBSCluster(cores=36, total_memory='90GB')
```


I've found that novices are more comfortable answering the questions on the bottom rather than the questions on the top.  Answering the questions on the top means that you already need to understand how dask-worker manages its keywords.  