### PR TITLE
Add documentation about experimental NERSC jupyter server

### DIFF
--- a/docs/configurations.rst
+++ b/docs/configurations.rst
@@ -55,7 +55,7 @@ It should be noted that the the following config file assumes you are running th
 
 Then you will run dask jobqueue directly on that interactive node. Note the distributed section that is set up to avoid having dask write to disk. This was due to some weird behavior with the local filesystem.
 
-Alternatively you may use the experimental `NERSC jupyterhub <https://jupyter-dev.nersc.gov/`_ which will launch a notebook server on a reserved large memory node of Cori. In this case no special interactive session is needed and dask jobqueue will perform as expected.
+Alternatively you may use the experimental `NERSC jupyterhub <https://jupyter-dev.nersc.gov/>`_ which will launch a notebook server on a reserved large memory node of Cori. In this case no special interactive session is needed and dask jobqueue will perform as expected.
 
 
 .. code-block:: yaml

--- a/docs/configurations.rst
+++ b/docs/configurations.rst
@@ -53,7 +53,9 @@ It should be noted that the the following config file assumes you are running th
 
     $ salloc -N 1 -C haswell --qos=interactive -t 04:00:00
 
-Then you will run dask jobqueue directly on that interactive node. Note the distributed section that is set up to avoid having dask write to disk. This was due to some weird behavior with the local filesystem. 
+Then you will run dask jobqueue directly on that interactive node. Note the distributed section that is set up to avoid having dask write to disk. This was due to some weird behavior with the local filesystem.
+
+Alternatively you may use the experimental `NERSC jupyterhub <https://jupyter-dev.nersc.gov/`_ which will launch a notebook server on a reserved large memory node of Cori. In this case no special interactive session is needed and dask jobqueue will perform as expected.
 
 
 .. code-block:: yaml
@@ -73,7 +75,7 @@ Then you will run dask jobqueue directly on that interactive node. Note the dist
             processes: 4
             queue: debug
             walltime: '00:10:00'
-            job-extra: ['-C haswell', '-L project, SCRATCH, cscratch1'] 
+            job-extra: ['-C haswell', '-L project, SCRATCH, cscratch1']
 
 
 ARM Stratus


### PR DESCRIPTION
Was disappointed that NERSC would not work with `dask-jobqueue` without running in a interactive session. I looked around and found that they offer a [jupyterhub server](https://www.nersc.gov/users/data-analytics/data-analytics-2/jupyter-and-rstudio/) that launches jupyter servers within the cluster cori. Tried it out with this [gist](https://gist.github.com/mrocklin/ef9ccd29a6ec5f4de84d6192be95042a#file-custom-futures-ipynb) and it worked just fine with no issues. 

Wanted to add this documentation to show others that it is possible to easily use dask-jobqueue with NERSC.