### PR TITLE
forward 'ip' to LocalCluster

### DIFF
--- a/dask_jobqueue/core.py
+++ b/dask_jobqueue/core.py
@@ -202,13 +202,16 @@ class JobQueueCluster(Cluster):
         #This attribute should be overriden
         self.job_header = None
 
+        # Find the IP address and (if requested) set interface for workers
+        localhost_kwargs = {}
         if interface:
-            host = get_ip_interface(interface)
+            localhost_kwargs['ip'] = get_ip_interface(interface)
             extra += ' --interface  %s ' % interface
         else:
-            host = socket.gethostname()
+            localhost_kwargs['ip'] = socket.gethostname()
+        localhost_kwargs.update(kwargs)
 
-        self.local_cluster = LocalCluster(n_workers=0, ip=host, **kwargs)
+        self.local_cluster = LocalCluster(n_workers=0, **localhost_kwargs)
 
         # Keep information on process, threads and memory, for use in
         # subclasses

--- a/dask_jobqueue/tests/test_jobqueue_core.py
+++ b/dask_jobqueue/tests/test_jobqueue_core.py
@@ -41,4 +41,3 @@ def test_forward_ip():
     with PBSCluster(walltime='00:02:00', processes=4, cores=8, memory='28GB',
                     name='dask-worker') as cluster:
         assert cluster.local_cluster.scheduler.ip == default_ip
-

--- a/dask_jobqueue/tests/test_jobqueue_core.py
+++ b/dask_jobqueue/tests/test_jobqueue_core.py
@@ -1,4 +1,5 @@
 import pytest
+import socket
 
 from dask_jobqueue import JobQueueCluster, PBSCluster, MoabCluster, SLURMCluster, SGECluster, LSFCluster
 
@@ -27,3 +28,16 @@ def test_repr(Cluster):
         assert 'cores=0' in cluster_repr
         assert 'memory=0 B' in cluster_repr
         assert 'workers=0' in cluster_repr
+
+
+def test_forward_ip():
+    ip = '127.0.0.1'
+    with PBSCluster(walltime='00:02:00', processes=4, cores=8, memory='28GB',
+                 name='dask-worker', ip=ip) as cluster:
+        assert cluster.local_cluster.scheduler.ip == ip
+
+    default_ip = socket.gethostbyname(socket.gethostname())
+    assert default_ip != ip
+    with PBSCluster(walltime='00:02:00', processes=4, cores=8, memory='28GB',
+                 name='dask-worker') as cluster:
+        assert cluster.local_cluster.scheduler.ip == default_ip

--- a/dask_jobqueue/tests/test_jobqueue_core.py
+++ b/dask_jobqueue/tests/test_jobqueue_core.py
@@ -33,11 +33,12 @@ def test_repr(Cluster):
 def test_forward_ip():
     ip = '127.0.0.1'
     with PBSCluster(walltime='00:02:00', processes=4, cores=8, memory='28GB',
-                 name='dask-worker', ip=ip) as cluster:
+                    name='dask-worker', ip=ip) as cluster:
         assert cluster.local_cluster.scheduler.ip == ip
 
     default_ip = socket.gethostbyname(socket.gethostname())
     assert default_ip != ip
     with PBSCluster(walltime='00:02:00', processes=4, cores=8, memory='28GB',
-                 name='dask-worker') as cluster:
+                    name='dask-worker') as cluster:
         assert cluster.local_cluster.scheduler.ip == default_ip
+


### PR DESCRIPTION
JobQueueCluster forwards any additional keyword arguments to LocalCluster. However, it fails to forward 'ip' to the LocalCluster as it is explicitly set. This commit allows the user to forward 'ip' to the LocalCluster.

Context:
My cluster head has two network interfaces (one facing only the workers and one facing the internet). I want the scheduler to only listen on the worker facing interface. The 'interface' argument would be well suited for this task but JobQueueCluster also forwards this interface to the workers. Unfortunately, not all my cluster nodes have the same interface names. Therefore, I have to use 'ip' to force the scheduler to listen on the worker facing interface (without forcing the workers itself to use a (potentially non-existing) interface).
Personally, I would prefer to not force the interface of the workers (in that case I could use 'interface' to set the interface of only the scheduler) but I assume you have a reason for doing so :)
