### PR TITLE
Flake8 and source code cleanup

### DIFF
--- a/dask_jobqueue/moab.py
+++ b/dask_jobqueue/moab.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 from .core import docstrings
 from .pbs import PBSCluster
 

--- a/dask_jobqueue/tests/__init__.py
+++ b/dask_jobqueue/tests/__init__.py
@@ -1,2 +1,4 @@
+# flake8: noqa
+from __future__ import absolute_import, division, print_function
 
 QUEUE_WAIT = 60  # seconds

--- a/dask_jobqueue/tests/test_jobqueue_core.py
+++ b/dask_jobqueue/tests/test_jobqueue_core.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 import pytest
 
 from dask_jobqueue import JobQueueCluster

--- a/dask_jobqueue/tests/test_pbs.py
+++ b/dask_jobqueue/tests/test_pbs.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 import sys
 from time import sleep, time
 

--- a/dask_jobqueue/tests/test_sge.py
+++ b/dask_jobqueue/tests/test_sge.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 from time import sleep, time
 
 import pytest

--- a/dask_jobqueue/tests/test_slurm.py
+++ b/dask_jobqueue/tests/test_slurm.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 import sys
 from time import sleep, time
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,7 @@ license-file = LICENSE.txt
 # https://flake8.readthedocs.io/en/latest/user/error-codes.html
 
 # Note: there cannot be spaces after comma's here
-exclude = __init__.py
+exclude = __init__.py,distributed/_concurrent_futures_thread.py
 ignore =
     # Extra space in brackets
     E20,
@@ -21,8 +21,29 @@ ignore =
     E721,
     # Assigning lambda expression
     E731,
+    # continuation line under-indented for hanging indent
+    E121,
+    # continuation line over-indented for hanging indent
+    E126,
+    # continuation line over-indented for visual indent
+    E127,
+    # E128 continuation line under-indented for visual indent
+    E128,
+    # multiple statements on one line (semicolon)
+    E702,
+    # line break before binary operator
+    W503,
+    # visually indented line with same indent as next logical line
+    E129,
+    # unexpected indentation
+    E116,
+    # redefinition of unused 'loop' from line 10
+    F811,
+    # local variable is assigned to but never used
+    F841,
     # Ambiguous variable names
     E741
+
 max-line-length = 120
 
 [versioneer]
@@ -40,3 +61,6 @@ test = pytest
 default_section=THIRDPARTY
 known_first_party=dask_jobqueue
 multi_line_output=4
+
+[bdist_wheel]
+universal = 1


### PR DESCRIPTION
closes #38, closes #106 

This uses the flake8 config from distributed and adds some boilerplate future imports.