### PR TITLE
Add a cluster __repr__

### DIFF
--- a/dask_jobqueue/core.py
+++ b/dask_jobqueue/core.py
@@ -245,6 +245,21 @@ class JobQueueCluster(Cluster):
         if extra is not None:
             self._command_template += extra
 
+    def __repr__(self):
+        running_workers = sum(len(value) for value in self.running_jobs.values())
+        running_cores = running_workers * self.worker_threads
+        total_jobs = len(self.pending_jobs) + len(self.running_jobs)
+        total_cores = total_jobs * self.worker_cores
+        running_memory = running_workers * self.worker_memory / self.worker_processes
+        total_memory = total_jobs * self.worker_memory
+
+        return (self.__class__.__name__ +
+                '(%r, workers=%d, cores=%d/%d, memory=%s/%s, jobs=%d/%d, finished_jobs=%d)' %
+            (self.scheduler.address, running_workers, running_cores, total_cores,
+             format_bytes(running_memory), format_bytes(total_memory),
+             len(self.running_jobs), total_jobs, len(self.finished_jobs))
+            )
+
     @property
     def pending_jobs(self):
         """ Jobs pending in the queue """


### PR DESCRIPTION
Closes #91 

As mentionned in #91, I started from the format found in [LocalCluster](https://github.com/dask/distributed/blob/master/distributed/deploy/local.py#L143), in order to have some consistency:
````python
In [9]: cluster
Out[9]: PBSCluster('tcp://10.120.42.23:32961', workers=6, cores=12/16, memory=60.00 GB/80.00 GB, jobs=3/4, finished_jobs=0)

In [12]: cluster
Out[12]: PBSCluster('tcp://10.120.42.23:32961', workers=4, cores=8/8, memory=40.00 GB/40.00 GB, jobs=2/2, finished_jobs=1)
````

Please give me some return on the information displayed and the way it is printed.