### PR TITLE
WIP: Use regex for job-id lookup

### DIFF
--- a/dask_jobqueue/core.py
+++ b/dask_jobqueue/core.py
@@ -409,16 +409,20 @@ class JobQueueCluster(Cluster):
         return jobs
 
     def _job_id_from_submit_output(self, out):
-        msg = ('Could not parse job id from submission command output. Job id '
-               'regexp is {}, submission command output is: {}'.format(
-                    self.job_id_regexp, out))
+        no_match_msg = ('Could not parse job id from submission command '
+                        'output. Job id regexp is {}, submission command '
+                        'output is: {}'.format(self.job_id_regexp, out))
 
         match = re.search(self.job_id_regexp, out)
         if match is None:
-            raise ValueError(msg)
+            raise ValueError(no_match_msg)
 
-        job_id = match.group('job_id')
+        no_job_id_msg = ("You need to use a `job_id` named group, e.g. "
+                         "'(?P<job_id>\d+),' in your regexp. Your regexp was: "
+                         "{}".format(self.job_id_regexp))
+
+        job_id = match.groupdict().get('job_id')
         if job_id is None:
-            raise ValueError(msg)
+            raise ValueError(no_job_id_msg)
 
         return job_id

--- a/dask_jobqueue/core.py
+++ b/dask_jobqueue/core.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, division, print_function
 
 import logging
 import math
+import re
 import shlex
 import subprocess
 import sys
@@ -407,5 +408,4 @@ class JobQueueCluster(Cluster):
         return jobs
 
     def _job_id_from_submit_output(self, out):
-        raise NotImplementedError('_job_id_from_submit_output must be implemented when JobQueueCluster is '
-                                  'inherited. It should convert the stdout from submit_command to the job id')
+        return re.findall(r'\d+', out)[0]

--- a/dask_jobqueue/core.py
+++ b/dask_jobqueue/core.py
@@ -409,10 +409,16 @@ class JobQueueCluster(Cluster):
         return jobs
 
     def _job_id_from_submit_output(self, out):
+        msg = ('Could not parse job id from submission command output. Job id '
+               'regexp is {}, submission command output is: {}'.format(
+                    self.job_id_regexp, out))
+
         match = re.search(self.job_id_regexp, out)
+        if match is None:
+            raise ValueError(msg)
+
         job_id = match.group('job_id')
         if job_id is None:
-            raise ValueError('Could not parse job id from submission command'
-                             'output. Job id regexp is {}, submission command'
-                             'output is: {}'.format(self.job_id_regexp, out))
+            raise ValueError(msg)
+
         return job_id

--- a/dask_jobqueue/core.py
+++ b/dask_jobqueue/core.py
@@ -409,7 +409,7 @@ class JobQueueCluster(Cluster):
         return jobs
 
     def _job_id_from_submit_output(self, out):
-        regexp = r'(?P<job_id>{}'.format(self.job_id_regexp)
+        regexp = r'(?P<job_id>{})'.format(self.job_id_regexp)
         match = re.search(regexp, out)
         job_id = match.group('job_id')
         if job_id is None:

--- a/dask_jobqueue/core.py
+++ b/dask_jobqueue/core.py
@@ -409,20 +409,18 @@ class JobQueueCluster(Cluster):
         return jobs
 
     def _job_id_from_submit_output(self, out):
-        no_match_msg = ('Could not parse job id from submission command '
-                        'output. Job id regexp is {}, submission command '
-                        'output is: {}'.format(self.job_id_regexp, out))
-
         match = re.search(self.job_id_regexp, out)
         if match is None:
-            raise ValueError(no_match_msg)
-
-        no_job_id_msg = ("You need to use a `job_id` named group, e.g. "
-                         "'(?P<job_id>\d+),' in your regexp. Your regexp was: "
-                         "{}".format(self.job_id_regexp))
+            msg = ('Could not parse job id from submission command '
+                   "output.\nJob id regexp is {!r}\nSubmission command "
+                   'output is:\n{}'.format(self.job_id_regexp, out))
+            raise ValueError(msg)
 
         job_id = match.groupdict().get('job_id')
         if job_id is None:
-            raise ValueError(no_job_id_msg)
+            msg = ("You need to use a 'job_id' named group in your regexp, e.g. "
+                   "r'(?P<job_id>\d+)', in your regexp. Your regexp was: "
+                   "{!r}".format(self.job_id_regexp))
+            raise ValueError(msg)
 
         return job_id

--- a/dask_jobqueue/core.py
+++ b/dask_jobqueue/core.py
@@ -139,7 +139,7 @@ class JobQueueCluster(Cluster):
     cancel_command = None
     scheduler_name = ''
     _adaptive_options = {'worker_key': lambda ws: _job_id_from_worker_name(ws.name)}
-    job_id_regexp = r'(?P<job_id>{})'
+    job_id_regexp = r'(?P<job_id>\d+)'
 
     def __init__(self,
                  name=None,

--- a/dask_jobqueue/core.py
+++ b/dask_jobqueue/core.py
@@ -295,7 +295,7 @@ class JobQueueCluster(Cluster):
         for _ in range(num_jobs):
             with self.job_file() as fn:
                 out = self._submit_job(fn)
-                job = self._job_id_from_submit_output(out.decode())
+                job = _job_id_from_submit_output(out.decode())
                 logger.debug("started job: %s" % job)
                 self.pending_jobs[job] = {}
 

--- a/dask_jobqueue/core.py
+++ b/dask_jobqueue/core.py
@@ -407,5 +407,6 @@ class JobQueueCluster(Cluster):
             del self.pending_jobs[job_id]
         return jobs
 
-    def _job_id_from_submit_output(self, out):
-        return re.findall(r'\d+', out)[0]
+
+def _job_id_from_submit_output(out):
+    return re.findall(r'\d+', out)[0]

--- a/dask_jobqueue/core.py
+++ b/dask_jobqueue/core.py
@@ -139,7 +139,7 @@ class JobQueueCluster(Cluster):
     cancel_command = None
     scheduler_name = ''
     _adaptive_options = {'worker_key': lambda ws: _job_id_from_worker_name(ws.name)}
-    job_id_regexp = r'\d+'
+    job_id_regexp = r'(?P<job_id>{})'
 
     def __init__(self,
                  name=None,
@@ -409,8 +409,7 @@ class JobQueueCluster(Cluster):
         return jobs
 
     def _job_id_from_submit_output(self, out):
-        regexp = r'(?P<job_id>{})'.format(self.job_id_regexp)
-        match = re.search(regexp, out)
+        match = re.search(self.job_id_regexp, out)
         job_id = match.group('job_id')
         if job_id is None:
             raise ValueError('Could not parse job id from submission command'

--- a/dask_jobqueue/core.py
+++ b/dask_jobqueue/core.py
@@ -295,7 +295,7 @@ class JobQueueCluster(Cluster):
         for _ in range(num_jobs):
             with self.job_file() as fn:
                 out = self._submit_job(fn)
-                job = _job_id_from_submit_output(out.decode())
+                job = self._job_id_from_submit_output(out.decode())
                 logger.debug("started job: %s" % job)
                 self.pending_jobs[job] = {}
 
@@ -407,6 +407,6 @@ class JobQueueCluster(Cluster):
             del self.pending_jobs[job_id]
         return jobs
 
-
-def _job_id_from_submit_output(out):
-    return re.findall(r'\d+', out)[0]
+    @staticmethod
+    def _job_id_from_submit_output(out):
+        return re.findall(r'\d+', out)[0]

--- a/dask_jobqueue/jobqueue.yaml
+++ b/dask_jobqueue/jobqueue.yaml
@@ -19,6 +19,7 @@ jobqueue:
     env-extra: []
     resource-spec: null
     job-extra: []
+    jobid_regex: '(\d+)\.'
 
   sge:
     name: dask-worker

--- a/dask_jobqueue/jobqueue.yaml
+++ b/dask_jobqueue/jobqueue.yaml
@@ -19,7 +19,6 @@ jobqueue:
     env-extra: []
     resource-spec: null
     job-extra: []
-    jobid_regex: '(\d+)\.'
 
   sge:
     name: dask-worker

--- a/dask_jobqueue/lsf.py
+++ b/dask_jobqueue/lsf.py
@@ -102,9 +102,6 @@ class LSFCluster(JobQueueCluster):
 
         logger.debug("Job script: \n %s" % self.job_script())
 
-    def _job_id_from_submit_output(self, out):
-        return out.split('<')[1].split('>')[0].strip()
-
     def _submit_job(self, script_filename):
         piped_cmd = [self.submit_command + ' ' + script_filename + ' 2> /dev/null']
         return self._call(piped_cmd, shell=True)

--- a/dask_jobqueue/moab.py
+++ b/dask_jobqueue/moab.py
@@ -42,6 +42,3 @@ class MoabCluster(PBSCluster):
     submit_command = 'msub'
     cancel_command = 'canceljob'
     scheduler_name = 'moab'
-
-    def _job_id_from_submit_output(self, out):
-        return out.strip()

--- a/dask_jobqueue/pbs.py
+++ b/dask_jobqueue/pbs.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, division, print_function
 import logging
 import math
 import os
+import re
 
 import dask
 
@@ -102,7 +103,7 @@ class PBSCluster(JobQueueCluster):
         logger.debug("Job script: \n %s" % self.job_script())
 
     def _job_id_from_submit_output(self, out):
-        return out.split('.')[0].strip()
+        return re.findall('(\d+)\.', out)[0]
 
 
 def pbs_format_bytes_ceil(n):

--- a/dask_jobqueue/pbs.py
+++ b/dask_jobqueue/pbs.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import, division, print_function
 import logging
 import math
 import os
-import re
 
 import dask
 
@@ -101,11 +100,6 @@ class PBSCluster(JobQueueCluster):
         self.job_header = '\n'.join(header_lines)
 
         logger.debug("Job script: \n %s" % self.job_script())
-
-    def _job_id_from_submit_output(self, out):
-        jobid_regex = dask.config.get(
-            'jobqueue.%s.jobid_regex' % self.scheduler_name)
-        return re.findall(jobid_regex, out)[0]
 
 
 def pbs_format_bytes_ceil(n):

--- a/dask_jobqueue/pbs.py
+++ b/dask_jobqueue/pbs.py
@@ -103,7 +103,9 @@ class PBSCluster(JobQueueCluster):
         logger.debug("Job script: \n %s" % self.job_script())
 
     def _job_id_from_submit_output(self, out):
-        return re.findall('(\d+)\.', out)[0]
+        jobid_regex = dask.config.get(
+            'jobqueue.%s.jobid_regex' % self.scheduler_name)
+        return re.findall(jobid_regex, out)[0]
 
 
 def pbs_format_bytes_ceil(n):

--- a/dask_jobqueue/sge.py
+++ b/dask_jobqueue/sge.py
@@ -78,6 +78,3 @@ class SGECluster(JobQueueCluster):
         self.job_header = header_template % config
 
         logger.debug("Job script: \n %s" % self.job_script())
-
-    def _job_id_from_submit_output(self, out):
-        return out.strip()

--- a/dask_jobqueue/slurm.py
+++ b/dask_jobqueue/slurm.py
@@ -102,9 +102,6 @@ class SLURMCluster(JobQueueCluster):
 
         logger.debug("Job script: \n %s" % self.job_script())
 
-    def _job_id_from_submit_output(self, out):
-        return out.split(';')[0].strip()
-
 
 def slurm_format_bytes_ceil(n):
     """ Format bytes as text.

--- a/dask_jobqueue/tests/test_jobqueue_core.py
+++ b/dask_jobqueue/tests/test_jobqueue_core.py
@@ -83,11 +83,11 @@ def test_job_id_error_handling(Cluster, qsub_return_string):
         with pytest.raises(ValueError, match="Could not parse job id"):
             cluster.job_id_regexp = r'(?P<job_id>XXXX)'
             return_string = qsub_return_string.format(job_id='654321')
-            job_id = cluster._job_id_from_submit_output(return_string)
+            cluster._job_id_from_submit_output(return_string)
 
     # test for missing job_id  (Will fail for return string w/ number.)
     with Cluster(walltime='00:02:00', processes=4, cores=8, memory='28GB',
                  name='dask-worker') as cluster:
         with pytest.raises(ValueError, match="Could not parse job id"):
             return_string = qsub_return_string.format(job_id='XXXXX')
-            job_id = cluster._job_id_from_submit_output(return_string)
+            cluster._job_id_from_submit_output(return_string)

--- a/dask_jobqueue/tests/test_jobqueue_core.py
+++ b/dask_jobqueue/tests/test_jobqueue_core.py
@@ -6,8 +6,6 @@ import socket
 from dask_jobqueue import (JobQueueCluster, PBSCluster, MoabCluster,
                            SLURMCluster, SGECluster, LSFCluster)
 
-from dask_jobqueue.core import _job_id_from_submit_output
-
 
 def test_errors():
     with pytest.raises(NotImplementedError) as info:
@@ -57,6 +55,8 @@ def test_forward_ip():
      'Job <{jobid}> is submitted to default queue <normal>.',
      '{jobid}'])
 def test_jobid_from_qsub(qsub_return_string):
-    jobid = '654321'
-    qsub_return_string = qsub_return_string.format(jobid=jobid)
-    assert (_job_id_from_submit_output(qsub_return_string) == jobid)
+    original_jobid = '654321'
+    qsub_return_string = qsub_return_string.format(jobid=original_jobid)
+    parsed_jobid = JobQueueCluster._job_id_from_submit_output(
+        qsub_return_string.format(jobid=original_jobid))
+    assert parsed_jobid == original_jobid

--- a/dask_jobqueue/tests/test_jobqueue_core.py
+++ b/dask_jobqueue/tests/test_jobqueue_core.py
@@ -53,6 +53,6 @@ def test_forward_ip():
                           '{jobid}; asdf'])
 def test_jobid_from_qsub(qsub_return_string):
     jobid = '654321'
-    qsub_return_string = qsub_return_string.format(jobid)
+    qsub_return_string = qsub_return_string.format(jobid=jobid)
     assert (JobQueueCluster._job_id_from_submit_output(qsub_return_string) ==
             jobid)

--- a/dask_jobqueue/tests/test_jobqueue_core.py
+++ b/dask_jobqueue/tests/test_jobqueue_core.py
@@ -47,7 +47,7 @@ def test_forward_ip():
 
 
 @pytest.mark.parametrize('Cluster', [PBSCluster, MoabCluster, SLURMCluster,
-                                     SGECluster, LSFCluster, JobQueueCluster])
+                                     SGECluster, LSFCluster])
 @pytest.mark.parametrize(
     'qsub_return_string',
     ['{job_id}.admin01',
@@ -59,6 +59,7 @@ def test_forward_ip():
 def test_job_id_from_qsub(Cluster, qsub_return_string):
     original_job_id = '654321'
     qsub_return_string.format(job_id=original_job_id)
-    with Cluster() as cluster:
+    with Cluster(walltime='00:02:00', processes=4, cores=8, memory='28GB',
+                 name='dask-worker') as cluster:
         assert (original_job_id
                 == cluster._job_id_from_submit_output(qsub_return_string))

--- a/dask_jobqueue/tests/test_jobqueue_core.py
+++ b/dask_jobqueue/tests/test_jobqueue_core.py
@@ -48,11 +48,14 @@ def test_forward_ip():
         assert cluster.local_cluster.scheduler.ip == default_ip
 
 
-@pytest.mark.parametrize('qsub_return_string',
-                         ['Request {jobid}.asdf was sumbitted to queue 12.',
-                          '{jobid}',
-                          '  <{jobid}>  ',
-                          '{jobid}; asdf'])
+@pytest.mark.parametrize(
+    'qsub_return_string',
+    ['{jobid}.admin01',
+     'Request {jobid}.asdf was sumbitted to queue: standard.',
+     'sbatch: Submitted batch job {jobid}',
+     '{jobid};cluster',
+     'Job <{jobid}> is submitted to default queue <normal>.',
+     '{jobid}'])
 def test_jobid_from_qsub(qsub_return_string):
     jobid = '654321'
     qsub_return_string = qsub_return_string.format(jobid=jobid)

--- a/dask_jobqueue/tests/test_jobqueue_core.py
+++ b/dask_jobqueue/tests/test_jobqueue_core.py
@@ -59,8 +59,7 @@ def test_forward_ip():
 def test_job_id_from_qsub(Cluster, qsub_return_string):
     original_job_id = '654321'
     qsub_return_string = qsub_return_string.format(job_id=original_job_id)
-    with Cluster(walltime='00:02:00', processes=4, cores=8, memory='28GB',
-                 name='dask-worker') as cluster:
+    with Cluster(cores=1, memory='1GB') as cluster:
         assert (original_job_id
                 == cluster._job_id_from_submit_output(qsub_return_string))
 
@@ -68,17 +67,14 @@ def test_job_id_from_qsub(Cluster, qsub_return_string):
 @pytest.mark.parametrize('Cluster', [PBSCluster, MoabCluster, SLURMCluster,
                                      SGECluster, LSFCluster])
 def test_job_id_error_handling(Cluster):
-
-    # test for broken regexp
-    with Cluster(walltime='00:02:00', processes=4, cores=8, memory='28GB',
-                 name='dask-worker') as cluster:
+    # non-matching regexp
+    with Cluster(cores=1, memory='1GB') as cluster:
         with pytest.raises(ValueError, match="Could not parse job id"):
             return_string = "there is no number here"
             cluster._job_id_from_submit_output(return_string)
 
-    # test for missing job_id  (Will fail for return string w/ number.)
-    with Cluster(walltime='00:02:00', processes=4, cores=8, memory='28GB',
-                 name='dask-worker') as cluster:
+    # no job_id named group in the regexp
+    with Cluster(cores=1, memory='1GB') as cluster:
         with pytest.raises(ValueError, match="You need to use a"):
             return_string = 'Job <12345> submited to <normal>.'
             cluster.job_id_regexp = r'(\d+)'

--- a/dask_jobqueue/tests/test_jobqueue_core.py
+++ b/dask_jobqueue/tests/test_jobqueue_core.py
@@ -67,27 +67,19 @@ def test_job_id_from_qsub(Cluster, qsub_return_string):
 
 @pytest.mark.parametrize('Cluster', [PBSCluster, MoabCluster, SLURMCluster,
                                      SGECluster, LSFCluster])
-@pytest.mark.parametrize(
-    'qsub_return_string',
-    ['Request {job_id}.asdf was sumbitted to queue: standard.',
-     'sbatch: Submitted batch job {job_id}',
-     '{job_id};cluster',
-     'Job <{job_id}> is submitted to default queue <normal>.',
-     '{job_id}',
-     pytest.param('{job_id}.admin01', marks=pytest.mark.xfail)])
-def test_job_id_error_handling(Cluster, qsub_return_string):
+def test_job_id_error_handling(Cluster):
 
     # test for broken regexp
     with Cluster(walltime='00:02:00', processes=4, cores=8, memory='28GB',
                  name='dask-worker') as cluster:
         with pytest.raises(ValueError, match="Could not parse job id"):
             cluster.job_id_regexp = r'(?P<job_id>XXXX)'
-            return_string = qsub_return_string.format(job_id='654321')
+            return_string = "654321"
             cluster._job_id_from_submit_output(return_string)
 
     # test for missing job_id  (Will fail for return string w/ number.)
     with Cluster(walltime='00:02:00', processes=4, cores=8, memory='28GB',
                  name='dask-worker') as cluster:
-        with pytest.raises(ValueError, match="Could not parse job id"):
-            return_string = qsub_return_string.format(job_id='XXXXX')
+        with pytest.raises(ValueError, match="You need to use a"):
+            return_string = "there is no number here"
             cluster._job_id_from_submit_output(return_string)

--- a/dask_jobqueue/tests/test_jobqueue_core.py
+++ b/dask_jobqueue/tests/test_jobqueue_core.py
@@ -44,3 +44,15 @@ def test_forward_ip():
     with PBSCluster(walltime='00:02:00', processes=4, cores=8, memory='28GB',
                     name='dask-worker') as cluster:
         assert cluster.local_cluster.scheduler.ip == default_ip
+
+
+@pytest.mark.parametrize('qsub_return_string',
+                         ['Request {jobid}.asdf was sumbitted to queue 12.',
+                          '{jobid}',
+                          '  <{jobid}>  ',
+                          '{jobid}; asdf'])
+def test_jobid_from_qsub(qsub_return_string):
+    jobid = '654321'
+    qsub_return_string = qsub_return_string.format(jobid)
+    assert (JobQueueCluster._job_id_from_submit_output(qsub_return_string) ==
+            jobid)

--- a/dask_jobqueue/tests/test_jobqueue_core.py
+++ b/dask_jobqueue/tests/test_jobqueue_core.py
@@ -61,4 +61,4 @@ def test_job_id_from_qsub(Cluster, qsub_return_string):
     qsub_return_string.format(job_id=original_job_id)
     with Cluster() as cluster:
         assert (original_job_id
-                == cluster._job_id_from_submit_output(sub_return_string))
+                == cluster._job_id_from_submit_output(qsub_return_string))

--- a/dask_jobqueue/tests/test_jobqueue_core.py
+++ b/dask_jobqueue/tests/test_jobqueue_core.py
@@ -46,17 +46,19 @@ def test_forward_ip():
         assert cluster.local_cluster.scheduler.ip == default_ip
 
 
+@pytest.mark.parametrize('Cluster', [PBSCluster, MoabCluster, SLURMCluster,
+                                     SGECluster, LSFCluster, JobQueueCluster])
 @pytest.mark.parametrize(
     'qsub_return_string',
-    ['{jobid}.admin01',
-     'Request {jobid}.asdf was sumbitted to queue: standard.',
-     'sbatch: Submitted batch job {jobid}',
-     '{jobid};cluster',
-     'Job <{jobid}> is submitted to default queue <normal>.',
-     '{jobid}'])
-def test_jobid_from_qsub(qsub_return_string):
-    original_jobid = '654321'
-    qsub_return_string = qsub_return_string.format(jobid=original_jobid)
-    parsed_jobid = JobQueueCluster._job_id_from_submit_output(
-        qsub_return_string.format(jobid=original_jobid))
-    assert parsed_jobid == original_jobid
+    ['{job_id}.admin01',
+     'Request {job_id}.asdf was sumbitted to queue: standard.',
+     'sbatch: Submitted batch job {job_id}',
+     '{job_id};cluster',
+     'Job <{job_id}> is submitted to default queue <normal>.',
+     '{job_id}'])
+def test_job_id_from_qsub(Cluster, qsub_return_string):
+    original_job_id = '654321'
+    qsub_return_string.format(job_id=original_job_id)
+    with Cluster() as cluster:
+        assert (original_job_id
+                == cluster._job_id_from_submit_output(sub_return_string))

--- a/dask_jobqueue/tests/test_jobqueue_core.py
+++ b/dask_jobqueue/tests/test_jobqueue_core.py
@@ -73,13 +73,13 @@ def test_job_id_error_handling(Cluster):
     with Cluster(walltime='00:02:00', processes=4, cores=8, memory='28GB',
                  name='dask-worker') as cluster:
         with pytest.raises(ValueError, match="Could not parse job id"):
-            cluster.job_id_regexp = r'(?P<job_id>XXXX)'
-            return_string = "654321"
+            return_string = "there is no number here"
             cluster._job_id_from_submit_output(return_string)
 
     # test for missing job_id  (Will fail for return string w/ number.)
     with Cluster(walltime='00:02:00', processes=4, cores=8, memory='28GB',
                  name='dask-worker') as cluster:
         with pytest.raises(ValueError, match="You need to use a"):
-            return_string = "there is no number here"
+            return_string = 'Job <12345> submited to <normal>.'
+            cluster.job_id_regexp = r'(\d+)'
             cluster._job_id_from_submit_output(return_string)

--- a/dask_jobqueue/tests/test_jobqueue_core.py
+++ b/dask_jobqueue/tests/test_jobqueue_core.py
@@ -4,8 +4,9 @@ import pytest
 import socket
 
 from dask_jobqueue import (JobQueueCluster, PBSCluster, MoabCluster,
-                           SLURMCluster, SGECluster, LSFCluster,
-                           _job_id_from_submit_output)
+                           SLURMCluster, SGECluster, LSFCluster)
+
+from dask_jobqueue.core import _job_id_from_submit_output
 
 
 def test_errors():

--- a/dask_jobqueue/tests/test_jobqueue_core.py
+++ b/dask_jobqueue/tests/test_jobqueue_core.py
@@ -75,7 +75,7 @@ def test_job_id_error_handling(Cluster):
 
     # no job_id named group in the regexp
     with Cluster(cores=1, memory='1GB') as cluster:
-        with pytest.raises(ValueError, match="You need to use a"):
+        with pytest.raises(ValueError, match="You need to use a 'job_id' named group"):
             return_string = 'Job <12345> submited to <normal>.'
             cluster.job_id_regexp = r'(\d+)'
             cluster._job_id_from_submit_output(return_string)

--- a/dask_jobqueue/tests/test_jobqueue_core.py
+++ b/dask_jobqueue/tests/test_jobqueue_core.py
@@ -4,7 +4,8 @@ import pytest
 import socket
 
 from dask_jobqueue import (JobQueueCluster, PBSCluster, MoabCluster,
-                           SLURMCluster, SGECluster, LSFCluster)
+                           SLURMCluster, SGECluster, LSFCluster,
+                           _job_id_from_submit_output)
 
 
 def test_errors():
@@ -54,5 +55,4 @@ def test_forward_ip():
 def test_jobid_from_qsub(qsub_return_string):
     jobid = '654321'
     qsub_return_string = qsub_return_string.format(jobid=jobid)
-    assert (JobQueueCluster._job_id_from_submit_output(qsub_return_string) ==
-            jobid)
+    assert (_job_id_from_submit_output(qsub_return_string) == jobid)

--- a/dask_jobqueue/tests/test_jobqueue_core.py
+++ b/dask_jobqueue/tests/test_jobqueue_core.py
@@ -58,8 +58,36 @@ def test_forward_ip():
      '{job_id}'])
 def test_job_id_from_qsub(Cluster, qsub_return_string):
     original_job_id = '654321'
-    qsub_return_string.format(job_id=original_job_id)
+    qsub_return_string = qsub_return_string.format(job_id=original_job_id)
     with Cluster(walltime='00:02:00', processes=4, cores=8, memory='28GB',
                  name='dask-worker') as cluster:
         assert (original_job_id
                 == cluster._job_id_from_submit_output(qsub_return_string))
+
+
+@pytest.mark.parametrize('Cluster', [PBSCluster, MoabCluster, SLURMCluster,
+                                     SGECluster, LSFCluster])
+@pytest.mark.parametrize(
+    'qsub_return_string',
+    ['Request {job_id}.asdf was sumbitted to queue: standard.',
+     'sbatch: Submitted batch job {job_id}',
+     '{job_id};cluster',
+     'Job <{job_id}> is submitted to default queue <normal>.',
+     '{job_id}',
+     pytest.param('{job_id}.admin01', marks=pytest.mark.xfail)])
+def test_job_id_error_handling(Cluster, qsub_return_string):
+
+    # test for broken regexp
+    with Cluster(walltime='00:02:00', processes=4, cores=8, memory='28GB',
+                 name='dask-worker') as cluster:
+        with pytest.raises(ValueError, match="Could not parse job id"):
+            cluster.job_id_regexp = r'(?P<job_id>XXXX)'
+            return_string = qsub_return_string.format(job_id='654321')
+            job_id = cluster._job_id_from_submit_output(return_string)
+
+    # test for missing job_id  (Will fail for return string w/ number.)
+    with Cluster(walltime='00:02:00', processes=4, cores=8, memory='28GB',
+                 name='dask-worker') as cluster:
+        with pytest.raises(ValueError, match="Could not parse job id"):
+            return_string = qsub_return_string.format(job_id='XXXXX')
+            job_id = cluster._job_id_from_submit_output(return_string)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -285,5 +285,4 @@ problems are the following:
   We use submit command stdout to parse the job_id corresponding to the
   launched group of worker. If the parsing fails, then dask-jobqueue won't work
   as expected and may throw exceptions. You can have a look at the parsing
-  function in every ``JobQueueCluster`` implementation, see
-  ``_job_id_from_submit_output`` function.
+  function in the ``JobQueueCluster._job_id_from_submit_output`` function.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -285,4 +285,4 @@ problems are the following:
   We use submit command stdout to parse the job_id corresponding to the
   launched group of worker. If the parsing fails, then dask-jobqueue won't work
   as expected and may throw exceptions. You can have a look at the parsing
-  function in the ``JobQueueCluster._job_id_from_submit_output`` function.
+  function ``JobQueueCluster._job_id_from_submit_output``.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -285,4 +285,4 @@ problems are the following:
   We use submit command stdout to parse the job_id corresponding to the
   launched group of worker. If the parsing fails, then dask-jobqueue won't work
   as expected and may throw exceptions. You can have a look at the parsing
-  function in the ``core._job_id_from_submit_output`` function.
+  function in the ``JobQueueCluster._job_id_from_submit_output`` function.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -285,4 +285,4 @@ problems are the following:
   We use submit command stdout to parse the job_id corresponding to the
   launched group of worker. If the parsing fails, then dask-jobqueue won't work
   as expected and may throw exceptions. You can have a look at the parsing
-  function in the ``JobQueueCluster._job_id_from_submit_output`` function.
+  function in the ``core._job_id_from_submit_output`` function.


### PR DESCRIPTION
There's pbs schedulers returning with more verbose returns like: "Request 123456.asdfqwer submitted to queue: standard."

- [x] ~~f0566c8 should be fully compatible to the former version.~~
- [x] ~~It's probably a good thing to make the regex configurable.  I'll go ahead and add this as well.~~
- [x] Moving the regex matching in core.py
- [x] Making it a static string in the code, non configurable, with a value of r'\d+'
- [x] Deleting all _job_id_from_submit_output from JobQueueCluster subclasses
- [x] Adding tests
- [x] Updating trouble shooting section of the docs