### PR TITLE
Alternative way of listening on all interfaces for the bokeh server

### DIFF
--- a/dask_jobqueue/core.py
+++ b/dask_jobqueue/core.py
@@ -199,7 +199,7 @@ class JobQueueCluster(Cluster):
             extra += ' --interface  %s ' % interface
             kwargs.setdefault('ip', get_ip_interface(interface))
         else:
-            kwargs.setdefault('ip', socket.gethostname())
+            kwargs.setdefault('ip', '')
 
         # Bokeh diagnostics server should listen on all interfaces
         diagnostics_ip_and_port = ('', 8787)

--- a/dask_jobqueue/core.py
+++ b/dask_jobqueue/core.py
@@ -8,7 +8,6 @@ import sys
 import warnings
 from collections import OrderedDict
 from contextlib import contextmanager
-import socket
 
 import dask
 import docrep


### PR DESCRIPTION
This is an alternative to #129. Not sure which one is preferable to be completely honest ... one difference that may matter is that the scheduler does not listen on all interfaces. 

This is more in the spirit of https://github.com/dask/dask-jobqueue/issues/90#issue-340311408. I discovered through looking at the source code, that you can pass a `(address, port)` address fine to the `diagnostics_port` despite its name. Thanks to this, the bokeh diagnostics server will listen on all interfaces.

Close #126.


