### PR TITLE
Avoid KeyError on worker restart

### DIFF
--- a/dask_jobqueue/core.py
+++ b/dask_jobqueue/core.py
@@ -61,7 +61,8 @@ class JobQueuePlugin(SchedulerPlugin):
             if job_id in self.pending_jobs:
                 self.running_jobs[job_id] = self.pending_jobs.pop(job_id)
             elif job_id in self.finished_jobs:
-                logger.warning('Job %s has got a restarting worker %s', job_id, w)
+                logger.warning('Worker %s restart in Job %s. '
+                               'This can be due to memory issue.', w, job_id)
                 self.running_jobs[job_id] = self.finished_jobs.pop(job_id)
             else:
                 logger.error('Unknown job_id: %s for worker %s', job_id, w)

--- a/dask_jobqueue/core.py
+++ b/dask_jobqueue/core.py
@@ -57,8 +57,15 @@ class JobQueuePlugin(SchedulerPlugin):
 
         # if this is the first worker for this job, move job to running
         if job_id not in self.running_jobs:
-            logger.debug("this is a new job")
-            self.running_jobs[job_id] = self.pending_jobs.pop(job_id)
+            logger.debug("this is a new job or restarting worker")
+            if job_id in self.pending_jobs:
+                self.running_jobs[job_id] = self.pending_jobs.pop(job_id)
+            elif job_id in self.finished_jobs:
+                logger.warning('Job %s has got a restarting worker %s', job_id, w)
+                self.running_jobs[job_id] = self.finished_jobs.pop(job_id)
+            else:
+                logger.error('Unknown job_id: %s for worker %s', job_id, w)
+                self.running_jobs[job_id] = {}
 
         # add worker to dict of workers in this job
         self.running_jobs[job_id][w.name] = w


### PR DESCRIPTION
Closes #117.

Should help diagnose problem in #122.

I chose not to raise any Error, even if the job_id is not to be found in finished_jobs of the Scheduler plugin. User may want to manually add jobs and worker to the cluster? Though this is not a good practice.