### PR TITLE
Add a cluster detailed status method

### DIFF
--- a/dask_jobqueue/core.py
+++ b/dask_jobqueue/core.py
@@ -6,7 +6,7 @@ import shlex
 import subprocess
 import sys
 import warnings
-import html
+from xml.sax.saxutils import escape
 from collections import OrderedDict
 from contextlib import contextmanager
 
@@ -458,7 +458,7 @@ class ClusterStatus():
         if self.verbose:
             text += '    <ul>\n'
             for job_id, workers in self.cluster.running_jobs.items():
-                text += "      <li><b>%s: </b> %s\n" % (job_id, html.escape(str(workers)))
+                text += "      <li><b>%s: </b> %s\n" % (job_id, escape(str(workers)))
             text += "    </ul>\n"
         text += "  <li><b>Pending: </b>(cores=%d, memory=%s, workers=%d, jobs=%d)\n" % \
             self.pending_stats

--- a/dask_jobqueue/core.py
+++ b/dask_jobqueue/core.py
@@ -428,11 +428,11 @@ class ClusterStatus():
         running_cores = running_workers * self.cluster.worker_threads
         running_memory = running_workers * self.cluster.worker_memory / self.cluster.worker_processes
         self.running_stats = (running_cores, format_bytes(running_memory), running_workers,
-                  len(self.cluster.running_jobs))
+                              len(self.cluster.running_jobs))
         self.pending_stats = (len(self.cluster.pending_jobs) * self.cluster.worker_cores,
-                   format_bytes(len(self.cluster.pending_jobs) * self.cluster.worker_memory),
-                   len(self.cluster.pending_jobs) * self.cluster.worker_threads,
-                   len(self.cluster.pending_jobs))
+                              format_bytes(len(self.cluster.pending_jobs) * self.cluster.worker_memory),
+                              len(self.cluster.pending_jobs) * self.cluster.worker_threads,
+                              len(self.cluster.pending_jobs))
 
     def __repr__(self):
         status = '- Running: (cores=%d, memory=%s, workers=%d, jobs=%d)\n' % \
@@ -452,8 +452,8 @@ class ClusterStatus():
 
     def _repr_html_(self):
         text = ("<h3>Cluster Status</h3>\n"
-                    "<ul>\n"
-                    "  <li><b>Running: </b>(cores=%d, memory=%s, workers=%d, jobs=%d)\n") % \
+                "<ul>\n"
+                "  <li><b>Running: </b>(cores=%d, memory=%s, workers=%d, jobs=%d)\n") % \
             self.running_stats
         if self.verbose:
             text += '    <ul>\n'
@@ -473,6 +473,5 @@ class ClusterStatus():
             for job_id in self.cluster.finished_jobs.keys():
                 text += "      <li>%s\n" % job_id
             text += "    </ul>\n"
-        text +="</ul>\n"
+        text += "</ul>\n"
         return text
-

--- a/dask_jobqueue/core.py
+++ b/dask_jobqueue/core.py
@@ -395,6 +395,30 @@ class JobQueueCluster(Cluster):
         self.stop_all_jobs()
         self.local_cluster.close()
 
+    def status(self, verbose=False):
+        running_workers = sum(len(value) for value in self.running_jobs.values())
+        running_cores = running_workers * self.worker_threads
+        total_jobs = len(self.pending_jobs) + len(self.running_jobs)
+        total_workers = total_jobs * self.worker_processes
+        running_memory = running_workers * self.worker_memory / self.worker_processes
+
+        status = '- running: (cores=%d, memory=%s, workers=%d, jobs=%d)\n' % \
+                 (running_cores, format_bytes(running_memory), running_workers,
+                  len(self.running_jobs))
+        if verbose:
+            status += str(self.running_jobs) + '\n'
+        status += '- pending: (cores=%d, memory=%s, workers=%d, jobs=%d)\n' % \
+                  (len(self.pending_jobs) * self.worker_cores,
+                   format_bytes(len(self.pending_jobs) * self.worker_memory),
+                   len(self.pending_jobs) * self.worker_threads,
+                   len(self.pending_jobs))
+        if verbose:
+            status += str(list(self.pending_jobs.keys())) + '\n'
+        status += '- finished: (jobs=%d)\n' % len(self.finished_jobs)
+        if verbose:
+            status += str(list(self.finished_jobs.keys())) + '\n'
+        return status
+
     def __enter__(self):
         return self
 

--- a/dask_jobqueue/tests/test_jobqueue_core.py
+++ b/dask_jobqueue/tests/test_jobqueue_core.py
@@ -5,6 +5,7 @@ import socket
 
 from dask_jobqueue import (JobQueueCluster, PBSCluster, MoabCluster,
                            SLURMCluster, SGECluster, LSFCluster)
+from dask_jobqueue.core import ClusterStatus
 
 
 def test_errors():
@@ -44,3 +45,23 @@ def test_forward_ip():
     with PBSCluster(walltime='00:02:00', processes=4, cores=8, memory='28GB',
                     name='dask-worker') as cluster:
         assert cluster.local_cluster.scheduler.ip == default_ip
+
+
+def test_status():
+    with PBSCluster(walltime='00:02:00', processes=4, cores=8, memory='28GB',
+                    name='dask-worker') as cluster:
+        status = cluster.status()
+        assert isinstance(status, ClusterStatus)
+        assert 'Running: (cores=0, memory=0 B, workers=0, jobs=0)' in status.__repr__()
+        assert 'Pending: ' in status.__repr__()
+        assert 'Finished: ' in status.__repr__()
+        assert '<h3>Cluster Status</h3>' in status._repr_html_()
+        assert '<b>Running: </b>(cores=0, memory=0 B, workers=0, jobs=0)' in status._repr_html_()
+
+        status = cluster.status(True)
+        assert isinstance(status, ClusterStatus)
+        assert 'Running: ' in status.__repr__()
+        assert 'Pending: ' in status.__repr__()
+        assert 'Finished: ' in status.__repr__()
+        assert '<h3>Cluster Status</h3>' in status._repr_html_()
+        assert '<b>Running: </b>(cores=0, memory=0 B, workers=0, jobs=0)' in status._repr_html_()


### PR DESCRIPTION
Closes #11.

Main concern here: is this really useful in addition to cluster.__repr__ or client.__repr__.
Personnaly, I like to have kind of detailed status, but find it only useful in some specific cases.

Any other feedback quite welcome.