### PR TITLE
Use released version of dask and distributed in CI

### DIFF
--- a/ci/none.sh
+++ b/ci/none.sh
@@ -5,8 +5,6 @@ function jobqueue_before_install {
   ./ci/conda_setup.sh
   export PATH="$HOME/miniconda/bin:$PATH"
   conda install --yes -c conda-forge python=$TRAVIS_PYTHON_VERSION dask distributed flake8 pytest docrep
-  pip install --no-cache-dir git+https://github.com/dask/dask.git --upgrade --no-deps
-  pip install --no-cache-dir git+https://github.com/dask/distributed.git --upgrade --no-deps
 }
 
 function jobqueue_install {

--- a/ci/pbs/Dockerfile
+++ b/ci/pbs/Dockerfile
@@ -31,8 +31,6 @@ RUN curl -o miniconda.sh https://repo.continuum.io/miniconda/Miniconda3-latest-L
     /opt/anaconda/bin/conda clean -tipy && \
     rm -f miniconda.sh
 RUN conda install --yes -c conda-forge python=3.6 dask distributed flake8 pytest docrep
-RUN pip install --no-cache-dir git+https://github.com/dask/dask.git --upgrade --no-deps
-RUN pip install --no-cache-dir git+https://github.com/dask/distributed.git --upgrade --no-deps
 
 # Copy entrypoint and other needed scripts
 COPY ./*.sh /

--- a/ci/slurm/Dockerfile
+++ b/ci/slurm/Dockerfile
@@ -6,8 +6,6 @@ RUN curl -o miniconda.sh https://repo.continuum.io/miniconda/Miniconda3-latest-L
     rm -f miniconda.sh
 ENV PATH /opt/anaconda/bin:$PATH
 RUN conda install --yes -c conda-forge python=3.6 dask distributed flake8 pytest docrep
-RUN pip install --no-cache-dir git+https://github.com/dask/dask.git --upgrade --no-deps
-RUN pip install --no-cache-dir git+https://github.com/dask/distributed.git --upgrade --no-deps
 
 ENV LC_ALL en_US.UTF-8
 


### PR DESCRIPTION
I think it was done like this because we needed development versions of dask and distributed at one point. But that's not the case anymore.