### PR TITLE
Handle dask-worker command args and `extra` kwargs as a list

### DIFF
--- a/dask_jobqueue/core.py
+++ b/dask_jobqueue/core.py
@@ -102,7 +102,7 @@ class JobQueueCluster(Cluster):
         Seconds to wait for a scheduler before closing workers
     local_directory : str
         Dask worker local directory for file spilling.
-    extra : str
+    extra : list
         Additional arguments to pass to `dask-worker`
     env_extra : list
         Other commands to add to script before launching worker.
@@ -228,22 +228,23 @@ class JobQueueCluster(Cluster):
 
         # dask-worker command line build
         dask_worker_command = '%(python)s -m distributed.cli.dask_worker' % dict(python=sys.executable)
-        self._command_template = ' '.join([dask_worker_command, self.scheduler.address])
-        self._command_template += " --nthreads %d" % self.worker_threads
+        command_args = [dask_worker_command, self.scheduler.address]
+        command_args += ['--nthreads', self.worker_threads]
         if processes is not None and processes > 1:
-            self._command_template += " --nprocs %d" % processes
+            command_args += ['--nprocs', processes]
 
         mem = format_bytes(self.worker_memory / self.worker_processes)
-        mem = mem.replace(' ', '')
-        self._command_template += " --memory-limit %s" % mem
-        self._command_template += " --name %s--${JOB_ID}--" % name
+        command_args += ['--memory-limit', mem.replace(' ', '')]
+        command_args += ['--name', '%s--${JOB_ID}--' % name]
 
         if death_timeout is not None:
-            self._command_template += " --death-timeout %s" % death_timeout
+            command_args += ['--death-timeout', death_timeout]
         if local_directory is not None:
-            self._command_template += " --local-directory %s" % local_directory
+            command_args += ['--local-directory', local_directory]
         if extra is not None:
-            self._command_template += ' ' + extra
+            command_args += extra
+
+        self._command_template = ' '.join(map(str,command_args))
 
     def __repr__(self):
         running_workers = sum(len(value) for value in self.running_jobs.values())

--- a/dask_jobqueue/core.py
+++ b/dask_jobqueue/core.py
@@ -201,7 +201,7 @@ class JobQueueCluster(Cluster):
         self.job_header = None
 
         if interface:
-            extra += ' --interface  %s ' % interface
+            extra += ['--interface', interface]
             kwargs.setdefault('ip', get_ip_interface(interface))
         else:
             kwargs.setdefault('ip', '')

--- a/dask_jobqueue/core.py
+++ b/dask_jobqueue/core.py
@@ -243,7 +243,7 @@ class JobQueueCluster(Cluster):
         if local_directory is not None:
             self._command_template += " --local-directory %s" % local_directory
         if extra is not None:
-            self._command_template += extra
+            self._command_template += ' ' + extra
 
     def __repr__(self):
         running_workers = sum(len(value) for value in self.running_jobs.values())

--- a/dask_jobqueue/core.py
+++ b/dask_jobqueue/core.py
@@ -244,7 +244,7 @@ class JobQueueCluster(Cluster):
         if extra is not None:
             command_args += extra
 
-        self._command_template = ' '.join(map(str,command_args))
+        self._command_template = ' '.join(map(str, command_args))
 
     def __repr__(self):
         running_workers = sum(len(value) for value in self.running_jobs.values())

--- a/dask_jobqueue/jobqueue.yaml
+++ b/dask_jobqueue/jobqueue.yaml
@@ -15,7 +15,7 @@ jobqueue:
     queue: null
     project: null
     walltime: '00:30:00'
-    extra: ""
+    extra: []
     env-extra: []
     resource-spec: null
     job-extra: []
@@ -36,7 +36,7 @@ jobqueue:
     queue: null
     project: null
     walltime: '00:30:00'
-    extra: ""
+    extra: []
     env-extra: []
     resource-spec: null
     job-extra: []
@@ -57,7 +57,7 @@ jobqueue:
     queue: null
     project: null
     walltime: '00:30:00'
-    extra: ""
+    extra: []
     env-extra: []
 
     resource-spec: null
@@ -78,7 +78,7 @@ jobqueue:
     queue: null
     project: null
     walltime: '00:30:00'
-    extra: ""
+    extra: []
     env-extra: []
     job-cpu: null
     job-mem: null
@@ -100,7 +100,7 @@ jobqueue:
     queue: null
     project: null
     walltime: '00:30:00'
-    extra: ""
+    extra: []
     env-extra: []
     resource-spec: null
     job-extra: []
@@ -121,7 +121,7 @@ jobqueue:
     queue: null
     project: null
     walltime: '00:30'
-    extra: ""
+    extra: []
     env-extra: []
     ncpus: null
     mem: null

--- a/dask_jobqueue/tests/test_jobqueue_core.py
+++ b/dask_jobqueue/tests/test_jobqueue_core.py
@@ -24,15 +24,15 @@ def test_threads_deprecation():
 
 
 def test_command_template():
-    with PBSCluster() as cluster:
+    with PBSCluster(cores=2) as cluster:
         assert '%s -m distributed.cli.dask_worker' % (sys.executable) \
                in cluster._command_template
-        assert ' --nthreads ' in cluster._command_template
+        assert ' --nthreads 2' in cluster._command_template
         assert ' --nprocs ' in cluster._command_template
         assert ' --memory-limit ' in cluster._command_template
         assert ' --name ' in cluster._command_template
 
-    with PBSCluster(death_timeout=60, local_directory='/scratch',
+    with PBSCluster(cores=2, death_timeout=60, local_directory='/scratch',
                     extra='--preload mymodule') as cluster:
         assert ' --death-timeout 60' in cluster._command_template
         assert ' --local-directory /scratch' in cluster._command_template

--- a/dask_jobqueue/tests/test_jobqueue_core.py
+++ b/dask_jobqueue/tests/test_jobqueue_core.py
@@ -24,7 +24,7 @@ def test_threads_deprecation():
 
 
 def test_command_template():
-    with PBSCluster(cores=2) as cluster:
+    with PBSCluster(cores=2, memory='4GB') as cluster:
         assert '%s -m distributed.cli.dask_worker' % (sys.executable) \
                in cluster._command_template
         assert ' --nthreads 2' in cluster._command_template
@@ -32,7 +32,7 @@ def test_command_template():
         assert ' --memory-limit ' in cluster._command_template
         assert ' --name ' in cluster._command_template
 
-    with PBSCluster(cores=2, death_timeout=60, local_directory='/scratch',
+    with PBSCluster(cores=2, memory='4GB', death_timeout=60, local_directory='/scratch',
                     extra='--preload mymodule') as cluster:
         assert ' --death-timeout 60' in cluster._command_template
         assert ' --local-directory /scratch' in cluster._command_template

--- a/dask_jobqueue/tests/test_jobqueue_core.py
+++ b/dask_jobqueue/tests/test_jobqueue_core.py
@@ -28,12 +28,11 @@ def test_command_template():
         assert '%s -m distributed.cli.dask_worker' % (sys.executable) \
                in cluster._command_template
         assert ' --nthreads 2' in cluster._command_template
-        assert ' --nprocs ' in cluster._command_template
         assert ' --memory-limit ' in cluster._command_template
         assert ' --name ' in cluster._command_template
 
     with PBSCluster(cores=2, memory='4GB', death_timeout=60, local_directory='/scratch',
-                    extra='--preload mymodule') as cluster:
+                    extra=['--preload', 'mymodule']) as cluster:
         assert ' --death-timeout 60' in cluster._command_template
         assert ' --local-directory /scratch' in cluster._command_template
         assert ' --preload mymodule' in cluster._command_template


### PR DESCRIPTION
Fixes #156 