### PR TITLE
use correct documentation URL

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ LICENSE
 
 New BSD. See `License File <https://github.com/dask/dask-jobqueue/blob/master/LICENSE.txt>`__.
 
-.. _documentation: https://http://jobqueue.dask.org/en/latest/
+.. _documentation: https://jobqueue.dask.org/en/latest/
 .. |Build Status| image:: https://travis-ci.org/dask/dask-jobqueue.svg?branch=master
    :target: https://travis-ci.org/dask/dask-jobqueue
 .. |Doc Status| image:: https://readthedocs.org/projects/dask-jobqueue/badge/?version=latest


### PR DESCRIPTION
After reading http://blog.dask.org/2018/09/27/docs-refactor I remember that the Readme link was still pointing on readthedocs domain. This fixes it.