### PR TITLE
fix syntax error (missing comma)

### DIFF
--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -72,7 +72,7 @@ LSF Deployments
     from dask_jobqueue import LSFCluster
 
     cluster = LSFCluster(queue='general',
-                         project='cpp'
+                         project='cpp',
                          walltime='00:30',
                          cores=15,
                          memory='25GB')


### PR DESCRIPTION
LSF deployment example is missing a comma between kwargs. I added it.