### PR TITLE
added a memory string parser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ log
 *.swo
 .cache/
 .pytest_cache
+.mypy_cache/

--- a/dask_jobqueue/sge.py
+++ b/dask_jobqueue/sge.py
@@ -16,6 +16,9 @@ class SGECluster(JobQueueCluster):
     ----------
     queue : str
         Destination queue for each worker job. Passed to `#$ -q` option.
+    memory: str
+        The amount of memory requested per worker job. Passed to `#$ -l` option. Can be
+        specified in lieu of `resource_spec`.
     project : str
         Accounting string associated with each worker job. Passed to `#$ -A` option.
     resource_spec : str

--- a/dask_jobqueue/sge.py
+++ b/dask_jobqueue/sge.py
@@ -16,9 +16,6 @@ class SGECluster(JobQueueCluster):
     ----------
     queue : str
         Destination queue for each worker job. Passed to `#$ -q` option.
-    memory: str
-        The amount of memory requested per worker job. Passed to `#$ -l` option. Can be
-        specified in lieu of `resource_spec`.
     project : str
         Accounting string associated with each worker job. Passed to `#$ -A` option.
     resource_spec : str
@@ -66,9 +63,6 @@ class SGECluster(JobQueueCluster):
         if project is not None:
             header_lines.append('#$ -P %(project)s')
 
-        # Define resource specifications. There are only two cases allowed in this
-        # implementation: either specify using resource_spec, or specify using the rest of the
-        # kwargs.
         if resource_spec is not None:
             header_lines.append('#$ -l %(resource_spec)s')
         else:


### PR DESCRIPTION
cc: @jhamman, @sntgluca, @guillaumeeb 

I am proceeding with very small steps with this PR. This PR is a very focused one, and only adds a memory string parser, such that an end-user can specify the amount of RAM that they would like per worker node.

I have done the following:

- Added a memory string parser
- Updated the docstring to state that memory is a kwarg that can be specified in lieu of the resource string.

If I remember correctly, I can use multiple lines to specify resources. Hence:

```
#$ -l m_mem_free=8G
#$ -l h_rt=1500000
``` 

should be equivalent to:

```
#$ -l m_mem_free=8G,h_rt=1500000
```

@sntgluca, can you confirm/disprove my memory on this?

Still wondering about the following:

- Should I add a test for the memory string parser? If so, where is the best place to put it?
- Should I append to the example shown in the SGECluster docstring?

If merged, then this PR resolves in part #195, but not fully.