### PR TITLE
Typo in config fie for slurm

### DIFF
--- a/dask_jobqueue/jobqueue.yaml
+++ b/dask_jobqueue/jobqueue.yaml
@@ -89,7 +89,7 @@ jobqueue:
     env-extra: []
     job-cpu: null
     job-mem: null
-    job-extra: {}
+    job-extra: []
     log-directory: null
 
   moab:


### PR DESCRIPTION
I'm guessing this was a typo since it doesn't match the other resource managers