### PR TITLE
Add support for job [task] arrays in SGE/UGE

### DIFF
--- a/dask_jobqueue/sge.py
+++ b/dask_jobqueue/sge.py
@@ -86,7 +86,8 @@ class SGECluster(JobQueueCluster):
         logger.debug("Job script: \n %s" % self.job_script())
 
     def start_workers(self, n=1, ta=True):
-        __doc__ = docstrings.with_indents(""" Start workers as a task array
+        """
+        Start workers as a task array
 
         Parameters
         ----------
@@ -94,13 +95,14 @@ class SGECluster(JobQueueCluster):
             Total number of workers to start
         ta : bool
             If true, try to use task arrays
-        """, 4)
+        """
         logger.debug('starting %s workers', n)
 
         # Check if Task arrays can be used
         ta = ta and bool(os.getenv('SGE_TASK_ID', None))
 
         if ta:
+            logging.debug('Submission using task array')
             _original_command_template = self._command_template
             self._command_template = self._command_template.replace('${JOB_ID}', '${JOB_ID}.${SGE_TASK_ID}')
 
@@ -119,4 +121,5 @@ class SGECluster(JobQueueCluster):
             self.job_header = header_template
             self._command_template = _original_command_template
         else:
+            logging.debug('Submission using job ids')
             super(SGECluster, self).start_workers(n=n)

--- a/dask_jobqueue/sge.py
+++ b/dask_jobqueue/sge.py
@@ -85,9 +85,8 @@ class SGECluster(JobQueueCluster):
 
         logger.debug("Job script: \n %s" % self.job_script())
 
-
     def start_workers(self, n=1, ta=True):
-        """ Start workers as a task array and point each task to our local scheduler
+        __doc__ = docstrings.with_indents(""" Start workers as a task array
 
         Parameters
         ----------
@@ -95,7 +94,7 @@ class SGECluster(JobQueueCluster):
             Total number of workers to start
         ta : bool
             If true, try to use task arrays
-        """
+        """, 4)
         logger.debug('starting %s workers', n)
 
         # Check if Task arrays can be used
@@ -120,4 +119,4 @@ class SGECluster(JobQueueCluster):
             self.job_header = header_template
             self._command_template = _original_command_template
         else:
-            super().start_workers(n=n)
+            super(SGECluster, self).start_workers(n=n)

--- a/dask_jobqueue/sge.py
+++ b/dask_jobqueue/sge.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
 import logging
-import os
 import math
 
 import dask

--- a/dask_jobqueue/sge.py
+++ b/dask_jobqueue/sge.py
@@ -57,9 +57,7 @@ class SGECluster(JobQueueCluster):
 
         super(SGECluster, self).__init__(config_name=config_name, **kwargs)
 
-        # Use job arrays?
-        # Revert to separate jobs if 'SGE_TASK_ID' is not defined
-        self.use_job_arrays = use_job_arrays and bool(os.getenv('SGE_TASK_ID', None))
+        self.use_job_arrays = use_job_arrays
 
         header_lines = []
         if self.name is not None:

--- a/dask_jobqueue/tests/__init__.py
+++ b/dask_jobqueue/tests/__init__.py
@@ -1,3 +1,3 @@
 from __future__ import absolute_import, division, print_function
 
-QUEUE_WAIT = 120  # seconds
+QUEUE_WAIT = 15  # seconds

--- a/dask_jobqueue/tests/__init__.py
+++ b/dask_jobqueue/tests/__init__.py
@@ -1,3 +1,3 @@
 from __future__ import absolute_import, division, print_function
 
-QUEUE_WAIT = 15  # seconds
+QUEUE_WAIT = 120  # seconds

--- a/dask_jobqueue/tests/test_sge.py
+++ b/dask_jobqueue/tests/test_sge.py
@@ -3,6 +3,8 @@ from __future__ import absolute_import, division, print_function
 from time import sleep, time
 
 import pytest
+import subprocess
+
 from distributed import Client
 from distributed.utils_test import loop  # noqa: F401
 
@@ -14,7 +16,7 @@ from . import QUEUE_WAIT
 
 @pytest.mark.env("sge")  # noqa: F811
 def test_basic(loop):  # noqa: F811
-    with SGECluster(walltime='00:02:00', cores=8, processes=4, memory='2GB', loop=loop) as cluster:
+    with SGECluster(walltime=QUEUE_WAIT * 2, cores=8, processes=4, memory='2GB', loop=loop) as cluster:
         print(cluster.job_script())
         with Client(cluster, loop=loop) as client:
 
@@ -66,3 +68,40 @@ def test_config_name_sge_takes_custom_config():
     with dask.config.set({'jobqueue.sge-config-name': conf}):
         with SGECluster(config_name='sge-config-name') as cluster:
             assert cluster.name == 'myname'
+
+@pytest.mark.env("sge")  # noqa: F811
+def test_taskarrays(loop):  # noqa: F811
+
+    def scale_cluster(cluster, size):
+        """ Starts a small cluster and returns information on jobs and tasks """
+        cluster.scale(size)
+        # waiting to allow cluster to start (no pending jobs)
+        sleep(2)
+        while cluster.pending_jobs:
+            sleep(1)
+        sleep(2)
+        len_expected_jobs = len(list(cluster.pending_jobs.keys()) + list(cluster.running_jobs.keys()))
+        lines = [line for line in subprocess.check_output('qstat').decode().split('\n') if 'dask-work' in line]
+        len_unique_jids = len(set(line.split()[0] for line in lines))
+        len_scheduler_workers = len(cluster.scheduler.get_ncores())
+        return len_expected_jobs, len_unique_jids, len_scheduler_workers
+
+    with SGECluster(walltime=QUEUE_WAIT * 4, cores=1, processes=1, memory='2GB', loop=loop) as cluster:
+
+        # Test starting up one single core
+        len_expected_jobs, len_unique_jids, len_scheduler_workers = scale_cluster(cluster, 1)
+        assert len_expected_jobs == 1, 'There should be one unique job registered in the dask cluster. Found'.format(len_expected_jobs)
+        assert len_scheduler_workers == 1, 'There should be one worker registered in the scheduler. Found'.format(len_scheduler_workers)
+        assert len_unique_jids == 1, 'There should be one unique job running on SGE. Found'.format(len_unique_jids)
+
+        # Test adding 5 more jobs in one task array
+        len_expected_jobs, len_unique_jids, len_scheduler_workers = scale_cluster(cluster, 6)
+        assert len_expected_jobs == 6, 'There should be six unique jobs registered in the dask cluster. Found'.format(len_expected_jobs)
+        assert len_scheduler_workers == 6, 'There should be six workers registered in the scheduler. Found'.format(len_scheduler_workers)
+        assert len_unique_jids == 2, 'There should be two unique jobs running on SGE. Found'.format(len_unique_jids)        
+
+        # Test closing all task arrays
+        len_expected_jobs, len_unique_jids, len_scheduler_workers = scale_cluster(cluster, 0)
+        assert len_expected_jobs == 0, 'There should be no more unique jobs registered in the dask cluster. Found'.format(len_expected_jobs)
+        assert len_scheduler_workers == 0, 'There should be no more workers registered in the scheduler. Found'.format(len_scheduler_workers)
+        assert len_unique_jids == 0, 'There should be no more jobs running on SGE. Found'.format(len_unique_jids)

--- a/dask_jobqueue/tests/test_sge.py
+++ b/dask_jobqueue/tests/test_sge.py
@@ -18,7 +18,7 @@ from . import QUEUE_WAIT
 
 @pytest.mark.env("sge")  # noqa: F811
 def test_basic(loop):  # noqa: F811
-    with SGECluster(walltime=QUEUE_WAIT, cores=8, processes=4, memory='2GB', loop=loop) as cluster:
+    with SGECluster(walltime=QUEUE_WAIT * 2, cores=8, processes=4, memory='2GB', loop=loop) as cluster:
         print(cluster.job_script())
         with Client(cluster, loop=loop) as client:
 
@@ -95,7 +95,7 @@ def check_cluster_status(cluster):
 def test_taskarrays_setup(loop):  # noqa: F811
     # Test starting up one single core
 
-    with SGECluster(walltime=QUEUE_WAIT, cores=1, processes=1, memory='2GB',
+    with SGECluster(walltime=QUEUE_WAIT * 2, cores=1, processes=1, memory='2GB',
                     loop=loop, use_job_arrays=True) as cluster:
 
         cluster.scale(2)
@@ -125,7 +125,7 @@ def test_taskarrays_setup(loop):  # noqa: F811
 def test_taskarrays_scaleup(loop):  # noqa: F811
     # Test adding 5 more job arrays to a cluster with one job running
 
-    with SGECluster(walltime=QUEUE_WAIT, cores=1, processes=1, memory='2GB',
+    with SGECluster(walltime=QUEUE_WAIT * 2, cores=1, processes=1, memory='2GB',
                     loop=loop, use_job_arrays=True) as cluster:
 
         cluster.scale(1)
@@ -164,7 +164,7 @@ def test_taskarrays_scaleup(loop):  # noqa: F811
 @pytest.mark.env("sge")  # noqa: F811
 def test_taskarrays_scaledown(loop):  # noqa: F811
     # Test scaling down and closing all task arrays
-    with SGECluster(walltime=QUEUE_WAIT, cores=1, processes=1, memory='2GB',
+    with SGECluster(walltime=QUEUE_WAIT * 2, cores=1, processes=1, memory='2GB',
                     loop=loop, use_job_arrays=True) as cluster:
 
         cluster.scale(1)

--- a/dask_jobqueue/tests/test_sge.py
+++ b/dask_jobqueue/tests/test_sge.py
@@ -69,6 +69,7 @@ def test_config_name_sge_takes_custom_config():
         with SGECluster(config_name='sge-config-name') as cluster:
             assert cluster.name == 'myname'
 
+
 @pytest.mark.env("sge")  # noqa: F811
 def test_taskarrays(loop):  # noqa: F811
 

--- a/dask_jobqueue/tests/test_sge.py
+++ b/dask_jobqueue/tests/test_sge.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import, division, print_function
 from time import sleep, time
 
 import pytest
-import os
 import subprocess
 import logging
 

--- a/dask_jobqueue/tests/test_sge.py
+++ b/dask_jobqueue/tests/test_sge.py
@@ -18,7 +18,7 @@ from . import QUEUE_WAIT
 
 @pytest.mark.env("sge")  # noqa: F811
 def test_basic(loop):  # noqa: F811
-    with SGECluster(walltime=QUEUE_WAIT * 2, cores=8, processes=4, memory='2GB', loop=loop) as cluster:
+    with SGECluster(walltime=QUEUE_WAIT, cores=8, processes=4, memory='2GB', loop=loop) as cluster:
         print(cluster.job_script())
         with Client(cluster, loop=loop) as client:
 
@@ -87,6 +87,7 @@ def check_cluster_status(cluster):
     logging.info('Scheduler workers: %s' % scheduler_workers)
     len_scheduler_workers = len(scheduler_workers)
 
+    logging.debug('Expected values: %d %d %d' % (len_expected_jids, len_unique_jids, len_scheduler_workers))
     return len_expected_jids, len_unique_jids, len_scheduler_workers
 
 
@@ -94,114 +95,104 @@ def check_cluster_status(cluster):
 def test_taskarrays_setup(loop):  # noqa: F811
     # Test starting up one single core
 
-    with SGECluster(walltime=QUEUE_WAIT * 4, cores=1, processes=1, memory='2GB',
+    with SGECluster(walltime=QUEUE_WAIT, cores=1, processes=1, memory='2GB',
                     loop=loop, use_job_arrays=True) as cluster:
-        if os.getenv('SGE_TASK_ID', None):
 
-            cluster.scale(2)
+        cluster.scale(2)
 
-            start = time()
-            while not(cluster.pending_jobs):
-                sleep(0.100)
-                assert time() < start + QUEUE_WAIT
+        start = time()
+        while not(cluster.pending_jobs):
+            sleep(0.100)
+            assert time() < start + QUEUE_WAIT
 
-            while cluster.pending_jobs:
-                sleep(0.100)
-                assert time() < start + QUEUE_WAIT
+        while cluster.pending_jobs:
+            sleep(0.100)
+            assert time() < start + QUEUE_WAIT
 
-            len_expected_jobs, len_unique_jids, len_scheduler_workers = check_cluster_status(cluster)
-            assert len_expected_jobs == 1, \
-                'There should be one unique job registered in the dask cluster.' + \
-                ' Found {}'.format(len_expected_jobs)
-            assert len_scheduler_workers == 2, \
-                'There should be two workers registered in the scheduler.' + \
-                ' Found {}'.format(len_scheduler_workers)
-            assert len_unique_jids == 1, \
-                'There should be one unique job running on SGE.' + \
-                ' Found {}'.format(len_unique_jids)
-
-        else:
-            logging.info('Submission without task array. Skipped')
+        len_expected_jobs, len_unique_jids, len_scheduler_workers = check_cluster_status(cluster)
+        assert len_expected_jobs == 2, \
+            'There should be two independent jobs registered in the dask cluster.' + \
+            ' Found {}'.format(len_expected_jobs)
+        assert len_scheduler_workers == 2, \
+            'There should be two workers registered in the scheduler.' + \
+            ' Found {}'.format(len_scheduler_workers)
+        assert len_unique_jids == 1, \
+            'There should be one unique job running on SGE.' + \
+            ' Found {}'.format(len_unique_jids)
 
 
 @pytest.mark.env("sge")  # noqa: F811
 def test_taskarrays_scaleup(loop):  # noqa: F811
     # Test adding 5 more job arrays to a cluster with one job running
 
-    with SGECluster(walltime=QUEUE_WAIT * 4, cores=1, processes=1, memory='2GB',
+    with SGECluster(walltime=QUEUE_WAIT, cores=1, processes=1, memory='2GB',
                     loop=loop, use_job_arrays=True) as cluster:
-        if os.getenv('SGE_TASK_ID', None):
 
-            cluster.scale(1)
+        cluster.scale(1)
 
-            start = time()
-            while not(cluster.pending_jobs):
-                sleep(0.100)
-                assert time() < start + QUEUE_WAIT
+        start = time()
+        while not(cluster.pending_jobs):
+            sleep(0.100)
+            assert time() < start + QUEUE_WAIT
 
-            while cluster.pending_jobs:
-                sleep(0.100)
-                assert time() < start + QUEUE_WAIT
+        while cluster.pending_jobs:
+            sleep(0.100)
+            assert time() < start + QUEUE_WAIT
 
-            cluster.scale(6)
+        cluster.scale(6)
 
-            while not(cluster.pending_jobs):
-                sleep(0.100)
-                assert time() < start + QUEUE_WAIT
+        while not(cluster.pending_jobs):
+            sleep(0.100)
+            assert time() < start + QUEUE_WAIT
 
-            while cluster.pending_jobs:
-                sleep(0.100)
-                assert time() < start + QUEUE_WAIT
+        while cluster.pending_jobs:
+            sleep(0.100)
+            assert time() < start + QUEUE_WAIT
 
-            len_expected_jobs, len_unique_jids, len_scheduler_workers = check_cluster_status(cluster)
-            assert len_expected_jobs == 6, \
-                'There should be six unique jobs registered in the dask cluster.' + \
-                ' Found {}'.format(len_expected_jobs)
-            assert len_scheduler_workers == 6, \
-                'There should be six workers registered in the scheduler.' + \
-                ' Found {}'.format(len_scheduler_workers)
-            assert len_unique_jids == 2, \
-                'There should be two unique jobs running on SGE.' + \
-                ' Found {}'.format(len_unique_jids)
-        else:
-            logging.info('Submission without task array. Skipped')
+        len_expected_jobs, len_unique_jids, len_scheduler_workers = check_cluster_status(cluster)
+        assert len_expected_jobs == 6, \
+            'There should be six unique jobs registered in the dask cluster.' + \
+            ' Found {}'.format(len_expected_jobs)
+        assert len_scheduler_workers == 6, \
+            'There should be six workers registered in the scheduler.' + \
+            ' Found {}'.format(len_scheduler_workers)
+        assert len_unique_jids == 2, \
+            'There should be two unique jobs running on SGE.' + \
+            ' Found {}'.format(len_unique_jids)
 
 
 @pytest.mark.env("sge")  # noqa: F811
 def test_taskarrays_scaledown(loop):  # noqa: F811
     # Test scaling down and closing all task arrays
-    with SGECluster(walltime=QUEUE_WAIT * 4, cores=1, processes=1, memory='2GB',
+    with SGECluster(walltime=QUEUE_WAIT, cores=1, processes=1, memory='2GB',
                     loop=loop, use_job_arrays=True) as cluster:
-        if os.getenv('SGE_TASK_ID', None):
 
-            cluster.scale(1)
+        cluster.scale(1)
 
-            start = time()
-            while not(cluster.pending_jobs):
-                sleep(0.100)
-                assert time() < start + QUEUE_WAIT
+        start = time()
+        while not(cluster.pending_jobs):
+            sleep(0.100)
+            assert time() < start + QUEUE_WAIT
 
-            while cluster.pending_jobs:
-                sleep(0.100)
-                assert time() < start + QUEUE_WAIT
+        while cluster.pending_jobs:
+            sleep(0.100)
+            assert time() < start + QUEUE_WAIT
 
-            cluster.scale(0)
+        cluster.scale(0)
 
-            while cluster.running_jobs:
-                sleep(0.100)
-                assert time() < start + QUEUE_WAIT
-            # Wait for SGE to delete the job from its queue
-            sleep(2)
+        while cluster.running_jobs:
+            sleep(0.100)
+            assert time() < start + QUEUE_WAIT
+        # Wait for SGE to delete the job from its queue
+        sleep(2)
 
-            len_expected_jobs, len_unique_jids, len_scheduler_workers = check_cluster_status(cluster)
-            assert len_expected_jobs == 0, \
-                'There should be no more unique jobs registered in the dask cluster.' + \
-                ' Found {}'.format(len_expected_jobs)
-            assert len_scheduler_workers == 0, \
-                'There should be no more workers registered in the scheduler.' + \
-                ' Found {}'.format(len_scheduler_workers)
-            assert len_unique_jids == 0, \
-                'There should be no more jobs running on SGE.' + \
-                ' Found {}'.format(len_unique_jids)
-        else:
-            logging.info('Submission without task array. Skipped')
+        len_expected_jobs, len_unique_jids, len_scheduler_workers = check_cluster_status(cluster)
+        assert len_expected_jobs == 0, \
+            'There should be no more unique jobs registered in the dask cluster.' + \
+            ' Found {}'.format(len_expected_jobs)
+        assert len_scheduler_workers == 0, \
+            'There should be no more workers registered in the scheduler.' + \
+            ' Found {}'.format(len_scheduler_workers)
+        assert len_unique_jids == 0, \
+            'There should be no more jobs running on SGE.' + \
+            ' Found {}'.format(len_unique_jids)


### PR DESCRIPTION
This is the PoC to implement using job arrays (task arrays) #196
For the moment the implementation is _only available for the SGE cluster_.

The implementation redefines `self._cluster_template` to include the `'SGE_TASK_ID'` variable and rewrites the `start_workers()` method in `sge.py:SGECluster`.
There's a new test `test_sge.py:test_taskarrays()` to check basic stats on the new function.
I also changed the `QUEUE_WAIT` time in the tests to allow for more time (my tests required more time).

As a starting strategy, the use of task arrays is determined via a new `ta` argument in `SGECluster:start_workers()`.
* If `start_workers(ta=True)`:
the system checks if it can use task arrays and **runs the new function**.
* If `start_workers(ta=False)` or if task arrays cannot be run:
it defaults to the original `JobQueueCluster:start_workers()` function.

The `ta` argument is True by default, and it's not yet exposed to `scale()`. Which means, the use of task arrays is automatically activated by default.

