### PR TITLE
SGECluster docs

### DIFF
--- a/dask_jobqueue/sge.py
+++ b/dask_jobqueue/sge.py
@@ -12,6 +12,13 @@ logger = logging.getLogger(__name__)
 class SGECluster(JobQueueCluster):
     __doc__ = docstrings.with_indents(""" Launch Dask on a SGE cluster
 
+    .. note::
+        If you want a specific amount of RAM, both ``memory`` and ``resource_spec``
+        must be specified. The exact syntax of ``resource_spec`` is defined by your
+        GridEngine system administrator. The amount of ``memory`` requested should
+        match the ``resource_spec``, so that Dask's memory management system can
+        perform accurately.
+
     Parameters
     ----------
     queue : str

--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -55,9 +55,21 @@ SGE Deployments
 
 On systems which use SGE as the scheduler, ``SGECluster`` can be used.
 
-SGE systems have a lot of flexibility in how they are configured, hence it is not possible to use the ``memory`` keyword argument to automatically specify the amount of RAM requested. Instead, you specify the resources desired according to how your system is configured, using the ``resource_spec`` keyword argument, in addition to the ``memory`` keyword argument (which is used by Dask internally for memory management).
+SGE systems have a lot of flexibility in how they are configured, hence it is
+not possible to use the ``memory`` keyword argument to automatically specify
+the amount of RAM requested. Instead, you specify the resources desired
+according to how your system is configured, using the ``resource_spec`` keyword
+argument, in addition to the ``memory`` keyword argument (which is used by Dask
+internally for memory management, see `this
+<http://distributed.dask.org/en/latest/worker.html#memory-management>`_ for
+more details).
 
-In the example below, our system administrator has used the ``m_mem_free`` keyword argument to let us request for RAM. Other known keywords may include ``h_vmem`` and ``mem_free``. We had to check with our cluster documentation and/or system administrator for this. At the same time, we must also correctly specify the ``memory`` keyword argument, to enable Dask's memory management to do its work correctly.
+In the example below, our system administrator has used the ``m_mem_free``
+keyword argument to let us request for RAM. Other known keywords may include
+``mem_req`` and ``mem_free``. We had to check with our cluster documentation
+and/or system administrator for this. At the same time, we must also correctly
+specify the ``memory`` keyword argument, to enable Dask's memory management to
+do its work correctly.
 
 .. code-block:: python
 

--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -57,7 +57,7 @@ On systems which use SGE as the scheduler, ``SGECluster`` can be used.
 
 SGE systems have a lot of flexibility in how they are configured, hence it is not possible to use the ``memory`` keyword argument to automatically specify the amount of RAM requested. Instead, you specify the resources desired according to how your system is configured, using the ``resource_spec`` keyword argument, in addition to the ``memory`` keyword argument (which is used by Dask internally for memory management).
 
-In the example below, our system administrator has used the ``m_mem_free`` keyword argument to let us request for RAM. At the same time, we must also correctly specify the ``memory`` keyword argument, to enable Dask's memory management to do its work correctly.
+In the example below, our system administrator has used the ``m_mem_free`` keyword argument to let us request for RAM. Other known keywords may include ``h_vmem`` and ``mem_free``. We had to check with our cluster documentation and/or system administrator for this. At the same time, we must also correctly specify the ``memory`` keyword argument, to enable Dask's memory management to do its work correctly.
 
 .. code-block:: python
 

--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -53,7 +53,11 @@ can be used, called ``MoabCluster``:
 SGE Deployments
 ---------------
 
-On systems which use SGE as the scheduler, ``SGECluster`` can be used:
+On systems which use SGE as the scheduler, ``SGECluster`` can be used.
+
+SGE systems have a lot of flexibility in how they are configured, hence it is not possible to use the ``memory`` keyword argument to automatically specify the amount of RAM used. Instead, you must request for resources according to how your system is configured.
+
+In the example below, our system administrator has used the ``m_mem_free`` keyword argument to let us request for RAM. At the same time, we must also correctly specify the ``memory`` keyword argument, to enable Dask's memory management to do its work correctly.
 
 .. code-block:: python
 
@@ -62,7 +66,9 @@ On systems which use SGE as the scheduler, ``SGECluster`` can be used:
     cluster = SGECluster(queue='default.q',
                          walltime="1500000",
                          processes=10,
-                         memory='20GB')
+                         memory='20GB',  # this must be specified
+                         resource_spec='m_mem_free=20G',  # this also needs to be specified
+                         )
 
 LSF Deployments
 ---------------
@@ -140,7 +146,7 @@ to the dask-workers.
 
 The client can then be used as normal. Additionally, required resources can be
 specified for certain steps in the processing. For example:
-    
+
 .. code-block:: python
 
     def step_1_w_single_GPU(data):

--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -55,7 +55,7 @@ SGE Deployments
 
 On systems which use SGE as the scheduler, ``SGECluster`` can be used.
 
-SGE systems have a lot of flexibility in how they are configured, hence it is not possible to use the ``memory`` keyword argument to automatically specify the amount of RAM used. Instead, you must request for resources according to how your system is configured.
+SGE systems have a lot of flexibility in how they are configured, hence it is not possible to use the ``memory`` keyword argument to automatically specify the amount of RAM requested. Instead, you specify the resources desired according to how your system is configured, using the ``resource_spec`` keyword argument, in addition to the ``memory`` keyword argument (which is used by Dask internally for memory management).
 
 In the example below, our system administrator has used the ``m_mem_free`` keyword argument to let us request for RAM. At the same time, we must also correctly specify the ``memory`` keyword argument, to enable Dask's memory management to do its work correctly.
 
@@ -65,9 +65,9 @@ In the example below, our system administrator has used the ``m_mem_free`` keywo
 
     cluster = SGECluster(queue='default.q',
                          walltime="1500000",
-                         processes=10,
-                         memory='20GB',  # this must be specified
-                         resource_spec='m_mem_free=20G',  # this also needs to be specified
+                         processes=10,   # we request 10 processes per worker
+                         memory='20GB',  # for memory requests, this must be specified
+                         resource_spec='m_mem_free=20G',  # for memory requests, this also needs to be specified
                          )
 
 LSF Deployments


### PR DESCRIPTION
This PR closes #219. It adds a docstring update to `SGECluster`, and adds a note about memory resource requests in the Examples page.

In the limited amount of time that I attempted this PR, I was not able to build the docs locally. Hence, I have no screenshot of whether they render correctly or not. However, if they don't render properly, I am happy to edit the PR further.