### PR TITLE
Danpf/debug cluster

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,10 @@ matrix:
       env:
         - OS=ubuntu-14.04
         - JOBQUEUE=slurm
+    - python: "3.7"
+      env:
+        - OS=ubuntu-14.04
+        - JOBQUEUE=none
 
 env:
   global:

--- a/dask_jobqueue/__init__.py
+++ b/dask_jobqueue/__init__.py
@@ -7,6 +7,7 @@ from .slurm import SLURMCluster
 from .sge import SGECluster
 from .lsf import LSFCluster
 from .oar import OARCluster
+from .debug import DEBUGCluster
 
 from ._version import get_versions
 __version__ = get_versions()['version']

--- a/dask_jobqueue/debug.py
+++ b/dask_jobqueue/debug.py
@@ -34,10 +34,9 @@ class DEBUGCluster(JobQueueCluster):
     # Override class variables
     submit_command = 'python '
     cancel_command = 'kill '
-    scheduler_name = 'debug'
 
-    def __init__(self, **kwargs):
-        super(DEBUGCluster, self).__init__(**kwargs)
+    def __init__(self, config_name='debug', **kwargs):
+        super(DEBUGCluster, self).__init__(config_name=config_name, **kwargs)
         if "python" not in self.shebang:
             self.shebang = "#!/usr/bin/env python"
         og_cmd_template = self._command_template

--- a/dask_jobqueue/debug.py
+++ b/dask_jobqueue/debug.py
@@ -47,7 +47,7 @@ class DEBUGCluster(JobQueueCluster):
                                   "lf = open('logfile', 'a')\n"
                                   "print(subprocess.Popen(shlex.split(CMD), stderr=subprocess.STDOUT, stdout=lf).pid)")
                                   #"print(subprocess.Popen(shlex.split(CMD), stderr=subprocess.STDOUT, stdout=subprocess.DEVNULL).pid)"
-        self._command_template = self._command_template.replace("${JOB_ID}", "pid")
         self._command_template = self._command_template.replace('xxx', og_cmd_template)
+        self._command_template = self._command_template.replace("${JOB_ID}", "pid")
 
         self.job_header = ''

--- a/dask_jobqueue/debug.py
+++ b/dask_jobqueue/debug.py
@@ -1,0 +1,53 @@
+from __future__ import absolute_import, division, print_function
+
+import logging
+import os
+
+import dask
+
+from .core import JobQueueCluster, docstrings
+
+logger = logging.getLogger(__name__)
+
+
+class DEBUGCluster(JobQueueCluster):
+    __doc__ = docstrings.with_indents(""" Launch Dask locally with os.system calls
+
+    Parameters
+    ----------
+    %(JobQueueCluster.parameters)s
+
+    Examples
+    --------
+    >>> from dask_jobqueue import DEBUGCluster
+    >>> cluster = DEBUGCluster(queue='regular')
+    >>> cluster.scale(10)  # this may take a few seconds to launch
+
+    >>> from dask.distributed import Client
+    >>> client = Client(cluster)
+
+    This also works with adaptive clusters.  This automatically launches and kill workers based on load.
+
+    >>> cluster.adapt()
+    """, 4)
+
+    # Override class variables
+    submit_command = 'python '
+    cancel_command = 'kill '
+    scheduler_name = 'debug'
+
+    def __init__(self, **kwargs):
+        super(DEBUGCluster, self).__init__(**kwargs)
+        if "python" not in self.shebang:
+            self.shebang = "#!/usr/bin/env python"
+        og_cmd_template = self._command_template
+        self._command_template = ("import subprocess\n"
+                                  "import shlex\n"
+                                  "CMD='xxx'\n"
+                                  "lf = open('logfile', 'a')\n"
+                                  "print(subprocess.Popen(shlex.split(CMD), stderr=subprocess.STDOUT, stdout=lf).pid)")
+                                  #"print(subprocess.Popen(shlex.split(CMD), stderr=subprocess.STDOUT, stdout=subprocess.DEVNULL).pid)"
+        self._command_template = self._command_template.replace("${JOB_ID}", "pid")
+        self._command_template = self._command_template.replace('xxx', og_cmd_template)
+
+        self.job_header = ''

--- a/dask_jobqueue/jobqueue.yaml
+++ b/dask_jobqueue/jobqueue.yaml
@@ -138,3 +138,27 @@ jobqueue:
     mem: null
     job-extra: []
     log-directory: null
+
+  debug:
+    name: dask-worker
+
+    # Dask worker options
+    cores: 1                 # Total number of cores per job
+    memory: 1                # Total amount of memory per job
+    processes: 1                # Number of Python processes per job
+
+    interface: null             # Network interface to use like eth0 or ib0
+    death-timeout: 60           # Number of seconds to wait if a worker can not find a scheduler
+    local-directory: null       # Location of fast local storage like /scratch or $TMPDIR
+
+    # debug resource manager options
+    shebang: "#!/usr/bin/env python"
+    queue: null
+    project: null
+    walltime: '00:30'
+    extra: []
+    env-extra: []
+    ncpus: null
+    mem: null
+    job-extra: []
+    log-directory: null

--- a/dask_jobqueue/tests/test_debug.py
+++ b/dask_jobqueue/tests/test_debug.py
@@ -54,7 +54,7 @@ def test_debug_non_async():
             if count == 3:
                 for k, v in c._scheduler_identity["workers"].items():
                     pid = int(v['id'].split('--')[-2])
-                    subprocess.call(f"kill -15 {pid}", shell=True)
+                    subprocess.call("kill -15 {}".format(pid), shell=True)
 
     assert count == 10
 
@@ -92,7 +92,7 @@ async def _a_c_main():
             if count == 3:
                 for k, v in c._scheduler_identity["workers"].items():
                     pid = int(v['id'].split('--')[-2])
-                    subprocess.call(f"kill -15 {pid}", shell=True)
+                    subprocess.call("kill -15 {}".format(pid), shell=True)
     assert count == 10
 
     c.close()
@@ -126,7 +126,7 @@ async def _a_g_main():
     for k, v in c._scheduler_identity["workers"].items():
         pid = int(v['id'].split('--')[-2])
         print("killing pid", pid)
-        subprocess.call(f"kill -15 {pid}", shell=True)
+        subprocess.call("kill -15 {}".format(pid), shell=True)
 
     await asyncio.sleep(3)
 

--- a/dask_jobqueue/tests/test_debug.py
+++ b/dask_jobqueue/tests/test_debug.py
@@ -1,0 +1,196 @@
+from __future__ import absolute_import, division, print_function
+
+import asyncio
+import subprocess
+import psutil
+import time
+import sys
+
+from tornado import gen
+
+from dask_jobqueue import DEBUGCluster
+from distributed import Client, as_completed, LocalCluster
+from distributed.scheduler import KilledWorker
+
+
+@gen.coroutine
+def sleepy():
+    yield gen.sleep(1)
+
+
+def sleep_abit(x):
+    time.sleep(1)
+    return x+10
+
+
+def test_debug_non_async():
+    d = DEBUGCluster(cores=1, memory="1gb", extra=["--no-nanny", "--no-bokeh"])
+    d.adapt(minimum=3, maximum=3)
+    # d.scale(3)
+    c = Client(d)
+
+    while len(c._scheduler_identity["workers"]) < 3:
+        sleepy()
+
+    print("finally")
+    print(c._scheduler_identity)
+
+    ret = c.map(lambda x: sleep_abit(x), list(range(10)))
+    # proc = psutil.Process().pid
+    print("THIS IS", psutil.Process())
+
+    count = 0
+    subprocess.run("ps -u $USER", shell=True)
+    work_queue = as_completed(ret)
+    for ret in work_queue:
+        try:
+            result = ret.result()
+        except KilledWorker:
+            c.retry([ret])
+            work_queue.add(ret)
+        else:
+            print("result", result)
+            count += 1
+            if count == 3:
+                for k, v in c._scheduler_identity["workers"].items():
+                    pid = int(v['id'].split('--')[-2])
+                    subprocess.call(f"kill -15 {pid}", shell=True)
+
+    assert count == 10
+
+    c.close()
+
+
+async def _a_c_main():
+    d = DEBUGCluster(cores=1, memory="1gb", extra=["--no-nanny", "--no-bokeh"])
+    d.adapt(minimum=3, maximum=3)
+    # d.scale(3)
+    c = await Client(d, asynchronous=True)
+
+    while len(c._scheduler_identity["workers"]) < 3:
+        await asyncio.sleep(1)
+
+    print("finally")
+    print(c._scheduler_identity)
+
+    ret = c.map(lambda x: sleep_abit(x), list(range(10)))
+    # proc = psutil.Process().pid
+    print("THIS IS", psutil.Process())
+
+    count = 0
+    subprocess.run("ps -u $USER", shell=True)
+    work_queue = as_completed(ret)
+    for ret in work_queue:
+        try:
+            result = await ret
+        except KilledWorker:
+            c.retry([ret])
+            work_queue.add(ret)
+        else:
+            print("result", result)
+            count += 1
+            if count == 3:
+                for k, v in c._scheduler_identity["workers"].items():
+                    pid = int(v['id'].split('--')[-2])
+                    subprocess.call(f"kill -15 {pid}", shell=True)
+    assert count == 10
+
+    c.close()
+
+
+def test_async_as_completed():
+    loop = asyncio.get_event_loop()
+    loop.run_until_complete(_a_c_main())
+
+
+async def _a_g_main():
+    d = DEBUGCluster(cores=1, memory="1gb", extra=["--no-nanny", "--no-bokeh"])
+    d.adapt(minimum=3, maximum=3)
+    # d.scale(3)
+    c = await Client(d, asynchronous=True)
+
+    while len(c._scheduler_identity["workers"]) < 3:
+        await asyncio.sleep(1)
+
+    print("finally")
+    print(c._scheduler_identity)
+
+    ret = c.map(lambda x: sleep_abit(x), list(range(10)))
+    # proc = psutil.Process().pid
+    print("THIS IS", psutil.Process())
+
+    subprocess.run("ps -u $USER", shell=True)
+    gather_task = asyncio.ensure_future(asyncio.gather(*ret))
+    await asyncio.sleep(1.2)
+
+    for k, v in c._scheduler_identity["workers"].items():
+        pid = int(v['id'].split('--')[-2])
+        print("killing pid", pid)
+        subprocess.call(f"kill -15 {pid}", shell=True)
+
+    await asyncio.sleep(3)
+
+    print(c._scheduler_identity)
+
+    ret = await gather_task
+    print(ret)
+
+    c.close()
+
+
+def test_async_gather():
+    loop = asyncio.get_event_loop()
+    loop.run_until_complete(_a_g_main())
+
+
+# not sure
+# def local_main():
+#     d = LocalCluster(ncores=1, n_workers=1)
+#     d.adapt(minimum=3, maximum=3)
+#     # d.scale(3)
+#     c = Client(d)
+
+#     while len(c._scheduler_identity["workers"]) < 3:
+#         sleepy()
+
+#     print("finally")
+#     print(c._scheduler_identity)
+
+#     ret = c.map(lambda x: sleep_abit(x), list(range(10)))
+#     # proc = psutil.Process().pid
+#     print("THIS IS", psutil.Process())
+
+#     count = 0
+#     subprocess.run("ps -u $USER", shell=True)
+#     subprocess.run("pstree $USER -acp", shell=True)
+#     work_queue = as_completed(ret)
+#     for ret in work_queue:
+#         try:
+#             result = ret.result()
+#         except KilledWorker:
+#             c.retry([ret])
+#             work_queue.add(ret)
+#         else:
+#             print("result", result)
+#             count += 1
+#             if count == 3:
+#                 for k, v in c._scheduler_identity["workers"].items():
+#                     print(v)
+#                     pid = int(v['name'])
+#                     subprocess.call(f"kill -15 {pid}", shell=True)
+#     assert count == 10
+
+#     c.close()
+
+
+# if __name__ == "__main__":
+#     if sys.argv[1] == "async_a_c":
+#         loop = asyncio.get_event_loop()
+#         loop.run_until_complete(a_c_main())
+#     if sys.argv[1] == "async_g":
+#         loop = asyncio.get_event_loop()
+#         loop.run_until_complete(a_g_main())
+#     # elif sys.argv[1] == "local":
+#     #     local_main()
+#     else:
+#         main()

--- a/test_script.py
+++ b/test_script.py
@@ -5,12 +5,95 @@ import subprocess
 import psutil
 import time
 import sys
+import typing
 
 from tornado import gen
 
 from dask_jobqueue import DEBUGCluster
 from distributed import Client, as_completed, LocalCluster
 from distributed.scheduler import KilledWorker
+
+
+class possible_async_as_completed:
+    def __init__(self, futures: typing.List['future or task'],
+                 done: asyncio.Queue = None, todo: set = None,
+                 loop: 'loop' = None, timeout: int = None):
+        self.futures = futures
+        self.done = asyncio.Queue()
+        self.todo = set()
+        self.loop = loop
+        self.timeout = timeout
+
+    def add(self, waitable):
+        self.todo.add(asyncio.ensure_future(waitable))
+
+    # This is *not* a @coroutine!  It is just an iterator (yielding Futures).
+    def __iter__(self):
+        """Return an iterator whose values are coroutines.
+
+        When waiting for the yielded coroutines you'll get the results (or
+        exceptions!) of the original Futures (or coroutines), in the order
+        in which and as soon as they complete.
+
+        This differs from PEP 3148; the proper way to use this is:
+
+            for f in as_completed(fs):
+                result = await f  # The 'await' may raise.
+                # Use result.
+
+        If a timeout is specified, the 'await' will raise
+        TimeoutError when the timeout occurs before all Futures are done.
+
+        Note: The futures 'f' are not necessarily members of fs.
+        """
+        # if futures.isfuture(fs) or coroutines.iscoroutine(fs):
+        #     raise TypeError(f"expect a list of futures, not {type(fs).__name__}")
+        loop = self.loop if self.loop is not None else asyncio.get_event_loop()
+        self.todo = {asyncio.ensure_future(f, loop=loop) for f in set(self.futures)}
+
+        timeout_handle = None
+
+        def _on_timeout():
+            for f in self.todo:
+                f.remove_done_callback(_on_completion)
+                self.done.put_nowait(None)  # Queue a dummy value for _wait_for_one().
+            self.todo.clear()  # Can't do todo.remove(f) in the loop.
+
+        def _on_completion(f):
+            if not self.todo:
+                return  # _on_timeout() was here first.
+            self.todo.remove(f)
+            self.done.put_nowait(f)
+            if not self.todo and timeout_handle is not None:
+                timeout_handle.cancel()
+
+        for f in self.todo:
+            f.add_done_callback(_on_completion)
+        if self.todo and self.timeout is not None:
+            timeout_handle = loop.call_later(self.timeout, _on_timeout)
+        return self
+
+    async def _wait_for_one(self):
+        f = await self.done.get()
+        self.done.task_done()
+        if f is None:
+            # Dummy value from _on_timeout().
+            raise TimeoutError
+        # result = f.result()
+        try:
+            return f.result()  # May raise f.exception().
+        except Exception:
+            # TODO here we should be smart about killed workers or cancelled coroutines
+            raise
+            # print("FOUND EXCEPTIONSSSS")
+            # raise RuntimeError("DYINGDDD")
+            # pdb.set_trace()
+
+    def __next__(self):
+        if len(self.todo) or self.done.qsize():
+            return self._wait_for_one()
+        else:
+            raise StopIteration
 
 
 @gen.coroutine
@@ -54,7 +137,7 @@ def main():
             if count == 3:
                 for k, v in c._scheduler_identity["workers"].items():
                     pid = int(v['id'].split('--')[-2])
-                    subprocess.call(f"kill -15 {pid}", shell=True)
+                    subprocess.call("kill -15 {}".format(pid), shell=True)
     assert count == 10
 
     c.close()
@@ -91,7 +174,7 @@ async def a_c_main():
             if count == 3:
                 for k, v in c._scheduler_identity["workers"].items():
                     pid = int(v['id'].split('--')[-2])
-                    subprocess.call(f"kill -15 {pid}", shell=True)
+                    subprocess.call("kill -15 {}".format(pid), shell=True)
     assert count == 10
 
     c.close()
@@ -120,7 +203,7 @@ async def a_g_main():
     for k, v in c._scheduler_identity["workers"].items():
         pid = int(v['id'].split('--')[-2])
         print("killing pid", pid)
-        subprocess.call(f"kill -15 {pid}", shell=True)
+        subprocess.call("kill -15 {}".format(pid), shell=True)
 
     await asyncio.sleep(3)
 
@@ -176,7 +259,7 @@ if __name__ == "__main__":
     if sys.argv[1] == "async_a_c":
         loop = asyncio.get_event_loop()
         loop.run_until_complete(a_c_main())
-    if sys.argv[1] == "async_g":
+    elif sys.argv[1] == "async_g":
         loop = asyncio.get_event_loop()
         loop.run_until_complete(a_g_main())
     # elif sys.argv[1] == "local":

--- a/test_script.py
+++ b/test_script.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python
+
+import asyncio
+import subprocess
+import psutil
+import time
+import sys
+
+from tornado import gen
+
+from dask_jobqueue import DEBUGCluster
+from distributed import Client, as_completed, LocalCluster
+from distributed.scheduler import KilledWorker
+
+
+@gen.coroutine
+def sleepy():
+    yield gen.sleep(1)
+
+
+def sleep_abit(x):
+    time.sleep(1)
+    return x+10
+
+
+def main():
+    d = DEBUGCluster(cores=1, memory="1gb", extra=["--no-nanny", "--no-bokeh"])
+    # d.adapt(minimum=3, maximum=3)
+    d.scale(3)
+    c = Client(d)
+
+    while len(c._scheduler_identity["workers"]) < 3:
+        sleepy()
+
+    print("finally")
+    print(c._scheduler_identity)
+
+    ret = c.map(lambda x: sleep_abit(x), list(range(10)))
+    # proc = psutil.Process().pid
+    print("THIS IS", psutil.Process())
+
+    count = 0
+    subprocess.run("ps -u $USER", shell=True)
+    work_queue = as_completed(ret)
+    for ret in work_queue:
+        try:
+            result = ret.result()
+        except KilledWorker:
+            c.retry([ret])
+            work_queue.add(ret)
+        else:
+            print("result", result)
+            count += 1
+            if count == 3:
+                for k, v in c._scheduler_identity["workers"].items():
+                    pid = int(v['id'].split('--')[-2])
+                    subprocess.call(f"kill -15 {pid}", shell=True)
+    assert count == 10
+
+    c.close()
+
+
+async def a_c_main():
+    d = DEBUGCluster(cores=1, memory="1gb", extra=["--no-nanny", "--no-bokeh"])
+    d.adapt(minimum=3, maximum=3)
+    # d.scale(3)
+    c = await Client(d, asynchronous=True)
+
+    while len(c._scheduler_identity["workers"]) < 3:
+        await asyncio.sleep(1)
+
+    print("finally")
+    print(c._scheduler_identity)
+
+    ret = c.map(lambda x: sleep_abit(x), list(range(10)))
+    # proc = psutil.Process().pid
+    print("THIS IS", psutil.Process())
+
+    count = 0
+    subprocess.run("ps -u $USER", shell=True)
+    work_queue = as_completed(ret)
+    for ret in work_queue:
+        try:
+            result = await ret
+        except KilledWorker:
+            c.retry([ret])
+            work_queue.add(ret)
+        else:
+            print("result", result)
+            count += 1
+            if count == 3:
+                for k, v in c._scheduler_identity["workers"].items():
+                    pid = int(v['id'].split('--')[-2])
+                    subprocess.call(f"kill -15 {pid}", shell=True)
+    assert count == 10
+
+    c.close()
+
+
+async def a_g_main():
+    d = DEBUGCluster(cores=1, memory="1gb", extra=["--no-nanny", "--no-bokeh"])
+    d.adapt(minimum=3, maximum=3)
+    # d.scale(3)
+    c = await Client(d, asynchronous=True)
+
+    while len(c._scheduler_identity["workers"]) < 3:
+        await asyncio.sleep(1)
+
+    print("finally")
+    print(c._scheduler_identity)
+
+    ret = c.map(lambda x: sleep_abit(x), list(range(10)))
+    # proc = psutil.Process().pid
+    print("THIS IS", psutil.Process())
+
+    subprocess.run("ps -u $USER", shell=True)
+    gather_task = asyncio.ensure_future(asyncio.gather(*ret))
+    await asyncio.sleep(1.2)
+
+    for k, v in c._scheduler_identity["workers"].items():
+        pid = int(v['id'].split('--')[-2])
+        print("killing pid", pid)
+        subprocess.call(f"kill -15 {pid}", shell=True)
+
+    await asyncio.sleep(3)
+
+    print(c._scheduler_identity)
+
+    ret = await gather_task
+    print(ret)
+
+    c.close()
+
+
+# not sure
+# def local_main():
+#     d = LocalCluster(ncores=1, n_workers=1)
+#     d.adapt(minimum=3, maximum=3)
+#     # d.scale(3)
+#     c = Client(d)
+
+#     while len(c._scheduler_identity["workers"]) < 3:
+#         sleepy()
+
+#     print("finally")
+#     print(c._scheduler_identity)
+
+#     ret = c.map(lambda x: sleep_abit(x), list(range(10)))
+#     # proc = psutil.Process().pid
+#     print("THIS IS", psutil.Process())
+
+#     count = 0
+#     subprocess.run("ps -u $USER", shell=True)
+#     subprocess.run("pstree $USER -acp", shell=True)
+#     work_queue = as_completed(ret)
+#     for ret in work_queue:
+#         try:
+#             result = ret.result()
+#         except KilledWorker:
+#             c.retry([ret])
+#             work_queue.add(ret)
+#         else:
+#             print("result", result)
+#             count += 1
+#             if count == 3:
+#                 for k, v in c._scheduler_identity["workers"].items():
+#                     print(v)
+#                     pid = int(v['name'])
+#                     subprocess.call(f"kill -15 {pid}", shell=True)
+#     assert count == 10
+
+#     c.close()
+
+
+if __name__ == "__main__":
+    if sys.argv[1] == "async_a_c":
+        loop = asyncio.get_event_loop()
+        loop.run_until_complete(a_c_main())
+    if sys.argv[1] == "async_g":
+        loop = asyncio.get_event_loop()
+        loop.run_until_complete(a_g_main())
+    # elif sys.argv[1] == "local":
+    #     local_main()
+    else:
+        main()


### PR DESCRIPTION
EDIT4:
'edit2' fix is definitely wrong. currently thinking that this occurs when worker dies in the middle of sending data, really hard to test though...
EDIT3:
the 'edit2' fix doesn't seem to work all the time. seems to be related to when I scatter large files...?
EDIT2:
possible fix (not reproducible here(yet)) is to use this patch on distributed.  doesn't really make sense though...
```
diff --git a/distributed/client.py b/distributed/client.py
index 018d8ca6..d57fb7d5 100644
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -667,6 +667,7 @@ class Client(Node):
         asynchronous = kwargs.pop('asynchronous', None)
         if asynchronous or self.asynchronous or getattr(thread_state, 'asynchronous', False):
             callback_timeout = kwargs.pop('callback_timeout', None)
+            callback_timeout = 1200
             future = func(*args, **kwargs)
             if callback_timeout is not None:
                 future = gen.with_timeout(timedelta(seconds=callback_timeout),
```

EDIT:
i made tests (python3.7 only) for everything and got everything to pass on my end, suggesting that i'm not reproducing my failures properly.  I will continue to try to figure out what is causing my failures.

------

This is partially an issue, i don't expect this to get merged, but it might be useful. in advance, i realize this is mainly a distributed bug/fault, but it's pid tracking/killing is easier in jobqueue than it is in distributed.


Purpose:
i want to use dask on a backfill queue, IE, workers can be killed with signal 15 at any moment. This appears to work fine with gather, but never with as_completed.   Since we can be killed at any moment, I want to save my result files back at the scheduler using as_completed so things progress smoothly. not sure if relevant, but there's a large amount of data that has to be passed from the worker to the scheduler, (on the order of 10+GB), relatively small per job, but a very large amount of them, and i think saving them all for a gather call with be too expensive memory wise.

problem:
I consistently get errors that are similar to log1 or log2, or my jobs seem to stall and not repopulate.  

question:
I think while waiting in `as_completed` distributed needs to be checking for lost workers and updating the jobs of those workers as needed, not exactly sure how that should be done though...  additionally somehow when you cancel the futures they should be replaced or somehow re-run. At least that's what i surmise from my error logs....


__important__
if you want to try this PR, you have to add this to your distributed installation:
```
diff --git a/distributed/cli/dask_worker.py b/distributed/cli/dask_worker.py
index 645869fc..6fb22ad7 100755
--- a/distributed/cli/dask_worker.py
+++ b/distributed/cli/dask_worker.py
@@ -4,6 +4,7 @@ import atexit
 import logging
 import os
 from sys import exit
+import psutil
 
 import click
 from distributed import Nanny, Worker
@@ -101,6 +102,11 @@ def main(scheduler, host, worker_port, listen_address, contact_address,
          bokeh_port, local_directory, scheduler_file, interface,
          death_timeout, preload, preload_argv, bokeh_prefix, tls_ca_file,
          tls_cert, tls_key):
+
+    if "--pid--" in name:
+        name = name.replace("--pid--", "--{}--".format(psutil.Process().pid))
+        logger.info("Overriding name to process pid: {}".format(name))
+
     enable_proctitle_on_current()
     enable_proctitle_on_children()
 
```
Related:
https://github.com/dask/dask-jobqueue/issues/122
I tried some techniques from this PR, however I have still seen errors in my production runs with try: except blocks...

Attempts to solve:
I also tried my own as_completed (asyncio only), which appears to work, for my test case, but i'm still getting errors that look like log1 or log2 in production. 

A big problem is that I'm using asyncio and it doesn't seem to be a very popular option...

error log1
```
Traceback (most recent call last):
  File "run_on_all_targets.py", line 82, in <module>
    loop.run_until_complete(main())
  File "/home/danpf/.local/share/pyenv/versions/3.7.0/lib/python3.7/asyncio/base_events.py", line 568, in run_until_complete
    return future.result()
concurrent.futures._base.CancelledError
Exception ignored in: <generator object Scheduler.add_client at 0x15553f4295e8>
Traceback (most recent call last):
  File "/home/danpf/git/distributed/distributed/scheduler.py", line 2039, in add_client
    self.remove_client(client=client)
  File "/home/danpf/git/distributed/distributed/scheduler.py", line 2078, in remove_client
    remove_client_from_events
  File "/home/danpf/.local/share/pyenv/versions/3.7.0/lib/python3.7/site-packages/tornado/ioloop.py", line 638, in call_later
    return self.call_at(self.time() + delay, callback, *args, **kwargs)
  File "/home/danpf/.local/share/pyenv/versions/3.7.0/lib/python3.7/site-packages/tornado/platform/asyncio.py", line 145, in call_at
    functools.partial(stack_context.wrap(callback), *args, **kwargs))
  File "/home/danpf/.local/share/pyenv/versions/3.7.0/lib/python3.7/asyncio/base_events.py", line 641, in call_later
    context=context)
  File "/home/danpf/.local/share/pyenv/versions/3.7.0/lib/python3.7/asyncio/base_events.py", line 651, in call_at
    self._check_closed()
  File "/home/danpf/.local/share/pyenv/versions/3.7.0/lib/python3.7/asyncio/base_events.py", line 461, in _check_closed
    raise RuntimeError('Event loop is closed')
RuntimeError: Event loop is closed
```

error log2
```
...
JobQueueCluster.scale_up was called with a number of workers lower that what is already running or pending
Traceback (most recent call last):
  File "run_c_ext.py", line 86, in <module>
    loop.run_until_complete(main())
  File "/home/danpf/.local/share/pyenv/versions/3.7.0/lib/python3.7/asyncio/base_events.py", line 568, in run_until_complete
    return future.result()
concurrent.futures._base.CancelledError
distributed.scheduler - INFO - Clear task state
distributed.scheduler - INFO - Scheduler closing...
distributed.scheduler - INFO - Scheduler closing all comms
distributed.scheduler - INFO - Remove worker tcp://172.16.131.155:13673
distributed.core - INFO - Removing comms to tcp://172.16.131.155:13673
...
```
sorry for being lengthy..