### PR TITLE
added wait until n workers arguments

### DIFF
--- a/dask_jobqueue/deploy/cluster_manager.py
+++ b/dask_jobqueue/deploy/cluster_manager.py
@@ -86,7 +86,7 @@ class ClusterManager(object):
 
     def wait_until_n_workers(self, n):
         '''Block by sleeping until we have n active workers'''
-        while len(self.scheduler.workers) < n:
+        while n and len(self.scheduler.workers) < n:
             time.sleep(1)
 
     def adapt(self, minimum_cores=None, maximum_cores=None,

--- a/dask_jobqueue/deploy/cluster_manager.py
+++ b/dask_jobqueue/deploy/cluster_manager.py
@@ -84,9 +84,9 @@ class ClusterManager(object):
         self._adaptive_options = adaptive_options
         self._adaptive_options.setdefault('worker_key', self.worker_key)
 
-    def sleep_until_n_workers(self, n):
+    def wait_until_n_workers(self, n):
         '''Block by sleeping until we have n active workers'''
-        while self._count_active_workers() < n:
+        while len(self.scheduler.workers) < n:
             time.sleep(1)
 
     def adapt(self, minimum_cores=None, maximum_cores=None,
@@ -131,7 +131,7 @@ class ClusterManager(object):
                 kwargs['maximum'] = self._get_nb_workers_from_memory(maximum_memory)
         self._adaptive_options.update(kwargs)
         self._adaptive = Adaptive(self.scheduler, self, **self._adaptive_options)
-        self.sleep_until_n_workers(wait_until_n)
+        self.wait_until_n_workers(wait_until_n)
         return self._adaptive
 
     @property
@@ -212,7 +212,7 @@ class ClusterManager(object):
         # TODO we should not rely on scheduler loop here, self should have its
         # own loop
         self.scheduler.loop.add_callback(self._scale, n, cores, memory)
-        self.sleep_until_n_workers(wait_until_n)
+        self.wait_until_n_workers(wait_until_n)
 
     def _widget_status(self):
         workers = len(self.scheduler.workers)

--- a/dask_jobqueue/tests/test_slurm.py
+++ b/dask_jobqueue/tests/test_slurm.py
@@ -119,6 +119,19 @@ def test_basic(loop):
 
 
 @pytest.mark.env("slurm")  # noqa: F811
+def test_wait_until_n(loop):
+    with SLURMCluster(walltime='00:02:00', cores=2, processes=1, memory='2GB',
+                      job_extra=['-D /'], loop=loop) as cluster:
+        cluster.adapt(minimum=2, wait_until_n=2)
+        assert len(cluster.scheduler.workers) == 2
+
+    with SLURMCluster(walltime='00:02:00', cores=2, processes=1, memory='2GB',
+                      job_extra=['-D /'], loop=loop) as cluster:
+        cluster.scale(2, wait_until_n=2)
+        assert len(cluster.scheduler.workers) == 2
+
+
+@pytest.mark.env("slurm")  # noqa: F811
 def test_adaptive(loop):
     with SLURMCluster(walltime='00:02:00', cores=2, processes=1, memory='2GB',
                       job_extra=['-D /'], loop=loop) as cluster:

--- a/dask_jobqueue/tests/test_slurm.py
+++ b/dask_jobqueue/tests/test_slurm.py
@@ -118,12 +118,15 @@ def test_basic(loop):
 
 
 @pytest.mark.env("slurm")  # noqa: F811
-def test_wait_until_n(loop):
+def test_wait_until_n_adaptive(loop):
     with SLURMCluster(walltime='00:02:00', cores=2, processes=1, memory='2GB',
                       job_extra=['-D /'], loop=loop) as cluster:
         cluster.adapt(minimum=2, wait_until_n=2)
         assert len(cluster.scheduler.workers) == 2
 
+
+@pytest.mark.env("slurm")  # noqa: F811
+def test_wait_until_n_scale(loop):
     with SLURMCluster(walltime='00:02:00', cores=2, processes=1, memory='2GB',
                       job_extra=['-D /'], loop=loop) as cluster:
         cluster.scale(2, wait_until_n=2)

--- a/dask_jobqueue/tests/test_slurm.py
+++ b/dask_jobqueue/tests/test_slurm.py
@@ -118,22 +118,6 @@ def test_basic(loop):
 
 
 @pytest.mark.env("slurm")  # noqa: F811
-def test_wait_until_n_adaptive(loop):
-    with SLURMCluster(walltime='00:02:00', cores=2, processes=1, memory='2GB',
-                      job_extra=['-D /'], loop=loop) as cluster:
-        cluster.adapt(minimum=2, wait_until_n=2)
-        assert len(cluster.scheduler.workers) == 2
-
-
-@pytest.mark.env("slurm")  # noqa: F811
-def test_wait_until_n_scale(loop):
-    with SLURMCluster(walltime='00:02:00', cores=2, processes=1, memory='2GB',
-                      job_extra=['-D /'], loop=loop) as cluster:
-        cluster.scale(2, wait_until_n=2)
-        assert len(cluster.scheduler.workers) == 2
-
-
-@pytest.mark.env("slurm")  # noqa: F811
 def test_adaptive(loop):
     with SLURMCluster(walltime='00:02:00', cores=2, processes=1, memory='2GB',
                       job_extra=['-D /'], loop=loop) as cluster:
@@ -162,6 +146,22 @@ def test_adaptive(loop):
                 assert time() < start + QUEUE_WAIT
 
             assert cluster.finished_jobs
+
+
+@pytest.mark.env("slurm")  # noqa: F811
+def test_wait_until_n_adaptive(loop):
+    with SLURMCluster(walltime='00:02:00', cores=2, processes=1, memory='2GB',
+                      job_extra=['-D /'], loop=loop) as cluster:
+        cluster.adapt(minimum=2, wait_until_n=2)
+        assert len(cluster.scheduler.workers) == 2
+
+
+@pytest.mark.env("slurm")  # noqa: F811
+def test_wait_until_n_scale(loop):
+    with SLURMCluster(walltime='00:02:00', cores=2, processes=1, memory='2GB',
+                      job_extra=['-D /'], loop=loop) as cluster:
+        cluster.scale(2, wait_until_n=2)
+        assert len(cluster.scheduler.workers) == 2
 
 
 def test_config_name_slurm_takes_custom_config():


### PR DESCRIPTION
Sometimes my scheduler is very full and it can take me a very long time to get a worker.  This way, when I do something like:
```
cluster.adapt(minimum=10,wait_until_n=2)
...{setup client}...
client.scatter([mything])
```
I don't get a timeout error on the scatter if it takes me 1hr+ to get those workers.

not sure if you are actually interested in this feature, just posting in case you are.

related to
https://github.com/dask/distributed/issues/2454