### PR TITLE
Support older SLURM versions.

### DIFF
--- a/dask_jobqueue/slurm.py
+++ b/dask_jobqueue/slurm.py
@@ -48,7 +48,7 @@ class SLURMCluster(JobQueueCluster):
     """, 4)
 
     # Override class variables
-    submit_command = 'sbatch --parsable'
+    submit_command = 'sbatch'
     cancel_command = 'scancel'
 
     def __init__(self, queue=None, project=None, walltime=None, job_cpu=None, job_mem=None, job_extra=None,


### PR DESCRIPTION
`--parsable` exists for SLURM version >= 14-03-03-1 (released March 2014).

Fix #227.
