### PR TITLE
Simplify loop fixture usage in tests

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,14 +1,21 @@
 # content of conftest.py
 
+# Make loop fixture available in all tests
+from distributed.utils_test import loop  # noqa: F401
+
 import pytest
+
+
 def pytest_addoption(parser):
     parser.addoption("-E", action="store", metavar="NAME",
-        help="only run tests matching the environment NAME.")
+                     help="only run tests matching the environment NAME.")
+
 
 def pytest_configure(config):
     # register an additional marker
     config.addinivalue_line("markers",
-        "env(name): mark test to run only on named environment")
+                            "env(name): mark test to run only on named environment")
+
 
 def pytest_runtest_setup(item):
     envnames = [mark.args[0] for mark in item.iter_markers(name='env')]

--- a/dask_jobqueue/tests/test_lsf.py
+++ b/dask_jobqueue/tests/test_lsf.py
@@ -4,7 +4,6 @@ from time import sleep, time
 import dask
 import pytest
 from dask.distributed import Client
-from distributed.utils_test import loop  # noqa: F401
 
 from dask_jobqueue import LSFCluster
 
@@ -85,7 +84,7 @@ def test_job_script():
         assert '--nthreads 2 --nprocs 4 --memory-limit 7.00GB' in job_script
 
 
-@pytest.mark.env("lsf")  # noqa: F811
+@pytest.mark.env("lsf")
 def test_basic(loop):
     with LSFCluster(walltime='00:02', processes=1, cores=2, memory='2GB',
                     local_directory='/tmp', loop=loop) as cluster:
@@ -111,7 +110,7 @@ def test_basic(loop):
             assert not cluster.running_jobs
 
 
-@pytest.mark.env("lsf")  # noqa: F811
+@pytest.mark.env("lsf")
 def test_adaptive(loop):
     with LSFCluster(walltime='00:02', processes=1, cores=2, memory='2GB',
                     local_directory='/tmp', loop=loop) as cluster:
@@ -146,7 +145,7 @@ def test_adaptive(loop):
             assert cluster.finished_jobs
 
 
-@pytest.mark.env("lsf")  # noqa: F811
+@pytest.mark.env("lsf")
 def test_adaptive_grouped(loop):
     with LSFCluster(walltime='00:02', processes=1, cores=2, memory='2GB',
                     local_directory='/tmp', loop=loop) as cluster:
@@ -172,7 +171,7 @@ def test_adaptive_grouped(loop):
                 assert time() < start + QUEUE_WAIT
 
 
-def test_config(loop):  # noqa: F811
+def test_config(loop):
     with dask.config.set({'jobqueue.lsf.walltime': '00:02',
                           'jobqueue.lsf.local-directory': '/foo'}):
         with LSFCluster(loop=loop, cores=1, memory='2GB') as cluster:

--- a/dask_jobqueue/tests/test_pbs.py
+++ b/dask_jobqueue/tests/test_pbs.py
@@ -6,7 +6,6 @@ from time import sleep, time
 import dask
 import pytest
 from dask.distributed import Client
-from distributed.utils_test import loop  # noqa: F401
 
 from dask_jobqueue import MoabCluster, PBSCluster
 
@@ -86,7 +85,7 @@ def test_job_script(Cluster):
         assert '--nthreads 2 --nprocs 4 --memory-limit 7.00GB' in job_script
 
 
-@pytest.mark.env("pbs")  # noqa: F811
+@pytest.mark.env("pbs")
 def test_basic(loop):
     with PBSCluster(walltime='00:02:00', processes=1, cores=2, memory='2GB', local_directory='/tmp',
                     job_extra=['-V'], loop=loop) as cluster:
@@ -118,7 +117,7 @@ def test_basic(loop):
             assert not cluster.running_jobs
 
 
-@pytest.mark.env("pbs")  # noqa: F811
+@pytest.mark.env("pbs")
 def test_scale_cores_memory(loop):
     with PBSCluster(walltime='00:02:00', processes=1, cores=2, memory='2GB', local_directory='/tmp',
                     job_extra=['-V'], loop=loop) as cluster:
@@ -150,7 +149,7 @@ def test_scale_cores_memory(loop):
             assert not cluster.running_jobs
 
 
-@pytest.mark.env("pbs")  # noqa: F811
+@pytest.mark.env("pbs")
 def test_basic_scale_edge_cases(loop):
     with PBSCluster(walltime='00:02:00', processes=1, cores=2, memory='2GB', local_directory='/tmp',
                     job_extra=['-V'], loop=loop) as cluster:
@@ -168,7 +167,7 @@ def test_basic_scale_edge_cases(loop):
         assert not(cluster.pending_jobs or cluster.running_jobs)
 
 
-@pytest.mark.env("pbs")  # noqa: F811
+@pytest.mark.env("pbs")
 def test_adaptive(loop):
     with PBSCluster(walltime='00:02:00', processes=1, cores=2, memory='2GB', local_directory='/tmp',
                     job_extra=['-V'], loop=loop) as cluster:
@@ -193,7 +192,7 @@ def test_adaptive(loop):
             assert cluster.finished_jobs
 
 
-@pytest.mark.env("pbs")  # noqa: F811
+@pytest.mark.env("pbs")
 def test_adaptive_grouped(loop):
     with PBSCluster(walltime='00:02:00', processes=1, cores=2, memory='2GB', local_directory='/tmp',
                     job_extra=['-V'], loop=loop) as cluster:
@@ -219,7 +218,7 @@ def test_adaptive_grouped(loop):
                 assert time() < start + QUEUE_WAIT
 
 
-@pytest.mark.env("pbs")  # noqa: F811
+@pytest.mark.env("pbs")
 def test_adaptive_cores_mem(loop):
     with PBSCluster(walltime='00:02:00', processes=1, cores=2, memory='2GB', local_directory='/tmp',
                     job_extra=['-V'], loop=loop) as cluster:
@@ -244,7 +243,7 @@ def test_adaptive_cores_mem(loop):
             assert cluster.finished_jobs
 
 
-@pytest.mark.env("pbs")  # noqa: F811
+@pytest.mark.env("pbs")
 def test_scale_grouped(loop):
     with PBSCluster(walltime='00:02:00', processes=2, cores=2, memory='2GB', local_directory='/tmp',
                     job_extra=['-V'], loop=loop) as cluster:
@@ -292,7 +291,7 @@ def test_scale_grouped(loop):
             assert not cluster.running_jobs
 
 
-def test_config(loop):  # noqa: F811
+def test_config(loop):
     with dask.config.set({'jobqueue.pbs.walltime': '00:02:00',
                           'jobqueue.pbs.local-directory': '/foo'}):
         with PBSCluster(loop=loop, cores=1, memory='2GB') as cluster:

--- a/dask_jobqueue/tests/test_slurm.py
+++ b/dask_jobqueue/tests/test_slurm.py
@@ -5,7 +5,6 @@ from time import sleep, time
 
 import pytest
 from distributed import Client
-from distributed.utils_test import loop  # noqa: F401
 
 import dask
 
@@ -88,7 +87,7 @@ def test_job_script():
         assert '--nthreads 2 --nprocs 4 --memory-limit 7.00GB' in job_script
 
 
-@pytest.mark.env("slurm")  # noqa: F811
+@pytest.mark.env("slurm")
 def test_basic(loop):
     with SLURMCluster(walltime='00:02:00', cores=2, processes=1, memory='2GB',
                       job_extra=['-D /'], loop=loop) as cluster:
@@ -118,7 +117,7 @@ def test_basic(loop):
                 assert time() < start + QUEUE_WAIT
 
 
-@pytest.mark.env("slurm")  # noqa: F811
+@pytest.mark.env("slurm")
 def test_adaptive(loop):
     with SLURMCluster(walltime='00:02:00', cores=2, processes=1, memory='2GB',
                       job_extra=['-D /'], loop=loop) as cluster:


### PR DESCRIPTION
By putting the `loop` import in `conftest.py`, it is readily available in all tests.

This way we can get rid of the hacks we had for making flake8 happy (F401/F801 dance that does not seem to work anymore with the latest version of `flake8`, see https://github.com/dask/dask-jobqueue/pull/232#issuecomment-460215666).

I could not resist fixing a few flake8 violations in conftest.py.