### PR TITLE
Fix typos with codespell

### DIFF
--- a/ci/pbs/Dockerfile
+++ b/ci/pbs/Dockerfile
@@ -16,7 +16,7 @@ RUN bash /build.sh
 FROM centos:7.5.1804
 LABEL description="PBS Professional Open Source and conda"
 
-#The pbs master node name, can be overriden if needed
+#The pbs master node name, can be overridden if needed
 ENV PBS_MASTER pbs_master
 ENV PATH /opt/pbs/bin:/opt/anaconda/bin:$PATH
 ENV LANG en_US.UTF-8

--- a/ci/pbs/slave-entrypoint.sh
+++ b/ci/pbs/slave-entrypoint.sh
@@ -12,7 +12,7 @@ sed -i "s/PBS_START_COMM=.*/PBS_START_COMM=0/" $pbs_conf_file
 sed -i "s/PBS_START_MOM=.*/PBS_START_MOM=1/" $pbs_conf_file
 
 # Prevent PBS trying to use scp between host for stdout and stderr file of jobs
-# On standard PBS deployement, you would use a shared mount, or correctly configured passwordless scp
+# On standard PBS deployment, you would use a shared mount, or correctly configured passwordless scp
 echo "\$usecp *:/home/ /home/" >> $mom_conf_file
 echo "\$usecp *:/dask-jobqueue/ /tmp/" >> $mom_conf_file
 

--- a/dask_jobqueue/core.py
+++ b/dask_jobqueue/core.py
@@ -294,7 +294,7 @@ class JobQueueCluster(ClusterManager):
 
     @property
     def running_jobs(self):
-        """ Jobs with currenly active workers """
+        """ Jobs with currently active workers """
         return self._scheduler_plugin.running_jobs
 
     @property

--- a/dask_jobqueue/lsf.py
+++ b/dask_jobqueue/lsf.py
@@ -104,7 +104,7 @@ class LSFCluster(JobQueueCluster):
         header_lines.extend(['#BSUB %s' % arg for arg in job_extra])
         header_lines.append('JOB_ID=${LSB_JOBID%.*}')
 
-        # Declare class attribute that shall be overriden
+        # Declare class attribute that shall be overridden
         self.job_header = '\n'.join(header_lines)
 
         logger.debug("Job script: \n %s" % self.job_script())

--- a/dask_jobqueue/pbs.py
+++ b/dask_jobqueue/pbs.py
@@ -97,7 +97,7 @@ class PBSCluster(JobQueueCluster):
         header_lines.extend(['#PBS %s' % arg for arg in job_extra])
         header_lines.append('JOB_ID=${PBS_JOBID%.*}')
 
-        # Declare class attribute that shall be overriden
+        # Declare class attribute that shall be overridden
         self.job_header = '\n'.join(header_lines)
 
         logger.debug("Job script: \n %s" % self.job_script())

--- a/dask_jobqueue/slurm.py
+++ b/dask_jobqueue/slurm.py
@@ -100,7 +100,7 @@ class SLURMCluster(JobQueueCluster):
 
         header_lines.append('JOB_ID=${SLURM_JOB_ID%;*}')
 
-        # Declare class attribute that shall be overriden
+        # Declare class attribute that shall be overridden
         self.job_header = '\n'.join(header_lines)
 
         logger.debug("Job script: \n %s" % self.job_script())

--- a/dask_jobqueue/tests/test_jobqueue_core.py
+++ b/dask_jobqueue/tests/test_jobqueue_core.py
@@ -110,7 +110,7 @@ def test_job_id_error_handling(Cluster):
     # no job_id named group in the regexp
     with Cluster(cores=1, memory='1GB') as cluster:
         with pytest.raises(ValueError, match="You need to use a 'job_id' named group"):
-            return_string = 'Job <12345> submited to <normal>.'
+            return_string = 'Job <12345> submitted to <normal>.'
             cluster.job_id_regexp = r'(\d+)'
             cluster._job_id_from_submit_output(return_string)
 

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -22,7 +22,7 @@ Changelog
 - Bind scheduler bokeh UI to every network interfaces by default.
 - Adds an OAR job queue system implementation.
 - Adds an LSF job queue system implementation.
-- Adds some convenient methods to JobQueueCluster objetcs: ``__repr__``, 
+- Adds some convenient methods to JobQueueCluster objects: ``__repr__``, 
   ``stop_jobs()``, ``close()``.
 
 

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -81,7 +81,7 @@ You can still override configuration values with keyword arguments
 
 If you have imported ``dask_jobqueue`` then a blank ``jobqueue.yaml`` will be
 added automatically to ``~/.config/dask/jobqueue.yaml``.  You should use the
-section of that configuation file that corresponds to your job scheduler.
+section of that configuration file that corresponds to your job scheduler.
 Above we used PBS, but other job schedulers operate the same way.  You should
 be able to share these with colleagues.  If you can convince your IT staff
 you can also place such a file in ``/etc/dask/`` and it will affect all people

--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -142,7 +142,7 @@ SLURM Deployment: Providing additional arguments to the dask-workers
 Keyword arguments can be passed through to dask-workers. An example of such an
 argument is for the specification of abstract resources, described `here
 <http://distributed.dask.org/en/latest/resources.html>`_. This could be used
-to specify special hardware availibility that the scheduler is not aware of,
+to specify special hardware availability that the scheduler is not aware of,
 for example GPUs. Below, the arbitrary resources "ssdGB" and "GPU" are
 specified. Notice that the ``extra`` keyword is used to pass through arguments
 to the dask-workers.

--- a/docs/source/interactive.rst
+++ b/docs/source/interactive.rst
@@ -61,7 +61,7 @@ dashboard. Note that you can do SSH tunneling for both Jupyter and Dashboard in
 one command.
 
 A good example of using Jupyter along with dask-jobqueue and the Dashboard is
-availaible below:
+available below:
 
 .. raw:: html
 


### PR DESCRIPTION
`codespell` is a Python package to fix most common misspellings in text files. See [this](https://github.com/codespell-project/codespell) for more details.

I don't remember where I heard of codespell but it is used in the Linux kernel, according to [this](https://kernelnewbies.org/Outreachyfirstpatch#FirstKernelPatch.Git_post-commit_hooks).
