### PR TITLE
Use pytest rather than py.test

### DIFF
--- a/ci/none.sh
+++ b/ci/none.sh
@@ -21,7 +21,7 @@ function jobqueue_script {
   if [[ "$TRAVIS_PYTHON_VERSION" =~ ^[3-9].+ ]]; then
      black --exclude versioneer.py --check .
   fi
-  py.test --verbose
+  pytest --verbose
 }
 
 function jobqueue_after_script {

--- a/ci/pbs.sh
+++ b/ci/pbs.sh
@@ -19,7 +19,7 @@ function jobqueue_install {
 }
 
 function jobqueue_script {
-    docker exec -it -u pbsuser pbs_master /bin/bash -c "cd /dask-jobqueue; py.test dask_jobqueue --verbose -E pbs"
+    docker exec -it -u pbsuser pbs_master /bin/bash -c "cd /dask-jobqueue; pytest dask_jobqueue --verbose -E pbs"
 }
 
 function jobqueue_after_script {

--- a/ci/sge.sh
+++ b/ci/sge.sh
@@ -17,7 +17,7 @@ function jobqueue_install {
 }
 
 function jobqueue_script {
-    docker exec -it sge_master /bin/bash -c "cd /dask-jobqueue; py.test dask_jobqueue --verbose -E sge"
+    docker exec -it sge_master /bin/bash -c "cd /dask-jobqueue; pytest dask_jobqueue --verbose -E sge"
 }
 
 function jobqueue_after_script {

--- a/ci/slurm.sh
+++ b/ci/slurm.sh
@@ -18,7 +18,7 @@ function jobqueue_install {
 }
 
 function jobqueue_script {
-    docker exec -it slurmctld /bin/bash -c "cd /dask-jobqueue; py.test dask_jobqueue --verbose -E slurm"
+    docker exec -it slurmctld /bin/bash -c "cd /dask-jobqueue; pytest dask_jobqueue --verbose -E slurm"
 }
 
 function jobqueue_after_script {

--- a/docs/source/develop.rst
+++ b/docs/source/develop.rst
@@ -35,9 +35,9 @@ To get flake8 and black, just pip install them. You can also use pre-commit to a
 Test
 ----
 
-Test using ``py.test``::
+Test using ``pytest``::
 
-   py.test dask-jobqueue --verbose
+   pytest dask-jobqueue --verbose
 
 Test with Job scheduler
 -----------------------

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -43,8 +43,8 @@ You can also install directly from git master branch::
 Test
 ----
 
-Test dask-jobqueue with ``py.test``::
+Test dask-jobqueue with ``pytest``::
 
     git clone https://github.com/dask/dask-jobqueue.git
     cd dask-jobqueue
-    py.test dask_jobqueue
+    pytest dask_jobqueue


### PR DESCRIPTION
It's been a while since `pytest` command exists (pytest 3.0.0 released in August 2016). From [this](https://docs.pytest.org/en/latest/changelog.html#id760):

> Introduce pytest command as recommended entry point. Note that py.test still works and is not scheduled for removal. Closes proposal #1629. Thanks @obestwalter and @davehunt for the complete PR (#1633).