### PR TITLE
Deprecation warning for diagnostics_port

### DIFF
--- a/dask_jobqueue/core.py
+++ b/dask_jobqueue/core.py
@@ -243,7 +243,7 @@ class JobQueueCluster(ClusterManager):
             kwargs.setdefault("ip", "")
 
         # Bokeh diagnostics server should listen on all interfaces
-        kwargs.setdefault("diagnostics_port", ("", 8787))
+        kwargs.setdefault("dashboard_address", ("", 8787))
         self.local_cluster = LocalCluster(n_workers=0, **kwargs)
 
         # Keep information on process, cores, and memory, for use in subclasses

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-dask>=0.18.1
-distributed>=1.22
+dask>=1.2.0
+distributed>=1.27
 docrep
 pre-commit


### PR DESCRIPTION
...replace with `dashboard_address`

Fixes #267 