### PR TITLE
LSF: Add unit scaling other than MB

### DIFF
--- a/dask_jobqueue/jobqueue.yaml
+++ b/dask_jobqueue/jobqueue.yaml
@@ -139,6 +139,7 @@ jobqueue:
     mem: null
     job-extra: []
     log-directory: null
+    lsf-units: null
 
   htcondor:
     name: dask-worker

--- a/dask_jobqueue/lsf.py
+++ b/dask_jobqueue/lsf.py
@@ -33,7 +33,7 @@ class LSFCluster(JobQueueCluster):
         prepended with the #LSF prefix.
     lsf_units : str
         Unit system for large units in resource usage set by the 
-        LSF_UNIT_FOR_LIMTS in the lsf.conf file of a cluster.
+        LSF_UNIT_FOR_LIMITS in the lsf.conf file of a cluster.
     %(JobQueueCluster.parameters)s
 
     Examples

--- a/dask_jobqueue/lsf.py
+++ b/dask_jobqueue/lsf.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, division, print_function
 
 import logging
 import math
+import os
 
 import dask
 
@@ -30,6 +31,9 @@ class LSFCluster(JobQueueCluster):
     job_extra : list
         List of other LSF options, for example -u. Each option will be
         prepended with the #LSF prefix.
+    lsf_units : str
+        Unit system for large units in resource usage set by the 
+        LSF_UNIT_FOR_LIMTS in the lsf.conf file of a cluster.
     %(JobQueueCluster.parameters)s
 
     Examples
@@ -62,6 +66,7 @@ class LSFCluster(JobQueueCluster):
         mem=None,
         walltime=None,
         job_extra=None,
+        lsf_units=None,
         config_name="lsf",
         **kwargs
     ):
@@ -77,6 +82,8 @@ class LSFCluster(JobQueueCluster):
             walltime = dask.config.get("jobqueue.%s.walltime" % config_name)
         if job_extra is None:
             job_extra = dask.config.get("jobqueue.%s.job-extra" % config_name)
+        if lsf_units is None:
+            job_extra = dask.config.get("jobqueue.%s.lsf-units" % config_name)
 
         # Instantiate args and parameters from parent abstract class
         super(LSFCluster, self).__init__(config_name=config_name, **kwargs)
@@ -112,10 +119,11 @@ class LSFCluster(JobQueueCluster):
             # Compute default memory specifications
             mem = self.worker_memory
             logger.info(
-                "mem specification for LSF not set, initializing it to %s" % mem
+                "mem specification for LSF not set, initializing it to %s bytes" % mem
             )
         if mem is not None:
-            memory_string = lsf_format_bytes_ceil(mem)
+            lsf_units = lsf_units if lsf_units is not None else lsf_detect_units()
+            memory_string = lsf_format_bytes_ceil(mem, lsf_units=lsf_units)
             header_lines.append("#BSUB -M %s" % memory_string)
         if walltime is not None:
             header_lines.append("#BSUB -W %s" % walltime)
@@ -132,7 +140,7 @@ class LSFCluster(JobQueueCluster):
         return self._call(piped_cmd, shell=True)
 
 
-def lsf_format_bytes_ceil(n):
+def lsf_format_bytes_ceil(n, lsf_units="mb"):
     """ Format bytes as text
 
     Convert bytes to megabytes which LSF requires.
@@ -141,10 +149,54 @@ def lsf_format_bytes_ceil(n):
     ----------
     n: int
         Bytes
+    lsf_units: str
+        Units for the memory in 2 character shorthand, kb through eb
 
     Examples
     --------
     >>> lsf_format_bytes_ceil(1234567890)
     '1235'
     """
-    return "%d" % math.ceil(n / (1000 ** 2))
+    lsf_units = lsf_units.lower()
+    converter = {
+        "b": 0,
+        "kb": 1,
+        "mb": 2,
+        "gb": 3,
+        "tb": 4,
+        "pb": 5,
+        "eb": 6
+    }
+    return "%d" % math.ceil(n / (1000 ** converter[lsf_units]))
+
+
+def lsf_detect_units():
+    """ Try to autodetect the unit scaling on an LSF system
+
+    """
+    # Search for automatically, Using docs from LSF 9.1.3 for search/defaults
+    unit = "kb"  # Default fallback unit
+    try:
+        # Start looking for the LSF conf file
+        conf_dir = "/etc"  # Fall back directory
+        # Search the two environment variables the docs say it could be at (likely a typo in docs)
+        for conf_env in ["LSF_ENVDIR", "LSF_CONFDIR"]:
+            conf_search = os.environ.get(conf_env, None)
+            if conf_search is not None:
+                conf_dir = conf_search
+                break
+        conf_path = os.path.join(conf_dir, 'lsf.conf')
+        conf_file = open(conf_path, 'r').readlines()
+        # Reverse order search (in case defined twice, get the one which will actually be processed)
+        for line in conf_file[::-1]:
+            # Look for very specific line
+            line = line.strip()
+            if not line.strip().startswith("LSF_UNIT_FOR_LIMITS"):
+                continue
+            # Found the line, infer the unit, only first 2 chars after "="
+            unit = line.split("=")[1].lower()[:2]
+            break
+    # Trap the lsf.conf does not exist, and the conf file not setup right (i.e. "$VAR=xxx^" regex-form)
+    except (FileNotFoundError, IndexError):
+        pass
+    return unit

--- a/dask_jobqueue/lsf.py
+++ b/dask_jobqueue/lsf.py
@@ -83,7 +83,7 @@ class LSFCluster(JobQueueCluster):
         if job_extra is None:
             job_extra = dask.config.get("jobqueue.%s.job-extra" % config_name)
         if lsf_units is None:
-            job_extra = dask.config.get("jobqueue.%s.lsf-units" % config_name)
+            lsf_units = dask.config.get("jobqueue.%s.lsf-units" % config_name)
 
         # Instantiate args and parameters from parent abstract class
         super(LSFCluster, self).__init__(config_name=config_name, **kwargs)
@@ -197,6 +197,6 @@ def lsf_detect_units():
             unit = line.split("=")[1].lower()[:2]
             break
     # Trap the lsf.conf does not exist, and the conf file not setup right (i.e. "$VAR=xxx^" regex-form)
-    except (FileNotFoundError, IndexError):
+    except (EnvironmentError, IndexError):
         pass
     return unit

--- a/dask_jobqueue/tests/test_lsf.py
+++ b/dask_jobqueue/tests/test_lsf.py
@@ -1,11 +1,16 @@
+import os
+from shutil import rmtree
 import sys
+from textwrap import dedent
+import tempfile
 from time import sleep, time
 
 import dask
 import pytest
 from dask.distributed import Client
+from distributed.utils import parse_bytes
 
-from dask_jobqueue import LSFCluster
+from dask_jobqueue import LSFCluster, lsf
 
 from . import QUEUE_WAIT
 
@@ -255,3 +260,50 @@ def test_informative_errors():
     with pytest.raises(ValueError) as info:
         LSFCluster(memory="1GB", cores=None)
     assert "cores" in str(info.value)
+
+
+def lsf_unit_detection_helper(expected_unit, conf_text=None):
+    temp_dir = tempfile.mkdtemp()
+    current_lsf_envdir = os.environ.get("LSF_ENVDIR", None)
+    os.environ["LSF_ENVDIR"] = temp_dir
+    if conf_text is not None:
+        with open(os.path.join(temp_dir, "lsf.conf"), "w") as conf_file:
+            conf_file.write(conf_text)
+    memory_string = "13GB"
+    memory_base = parse_bytes(memory_string)
+    correct_memory = lsf.lsf_format_bytes_ceil(memory_base, lsf_units=expected_unit)
+    with LSFCluster(memory=memory_string, cores=1) as cluster:
+        assert "#BSUB -M %s" % correct_memory in cluster.job_header
+    rmtree(temp_dir)
+    if current_lsf_envdir is None:
+        del os.environ["LSF_ENVDIR"]
+    else:
+        os.environ["LSF_ENVDIR"] = current_lsf_envdir
+
+
+@pytest.mark.parametrize(
+    "lsf_units_string,expected_unit",
+    [
+        ("LSF_UNIT_FOR_LIMITS=MB", "mb"),
+        ("LSF_UNIT_FOR_LIMITS=G  # And a comment", "gb"),
+        ("#LSF_UNIT_FOR_LIMITS=NotDetected", "kb"),
+    ],
+)
+def test_lsf_unit_detection(lsf_units_string, expected_unit):
+    conf_text = dedent(
+        """
+        LSB_JOB_MEMLIMIT=Y
+        LSB_MOD_ALL_JOBS=N
+        LSF_PIM_SLEEPTIME_UPDATE=Y
+        LSF_PIM_LINUX_ENHANCE=Y
+        %s
+        LSB_DISABLE_LIMLOCK_EXCL=Y
+        LSB_SUBK_SHOW_EXEC_HOST=Y
+        """
+        % lsf_units_string
+    )
+    lsf_unit_detection_helper(expected_unit, conf_text)
+
+
+def test_lsf_unit_detection_without_file():
+    lsf_unit_detection_helper("kb", conf_text=None)

--- a/dask_jobqueue/tests/test_lsf.py
+++ b/dask_jobqueue/tests/test_lsf.py
@@ -230,6 +230,7 @@ def test_config_name_lsf_takes_custom_config():
         "memory": "2 GB",
         "walltime": "00:02",
         "job-extra": [],
+        "lsf-units": "TB",
         "name": "myname",
         "processes": 1,
         "interface": None,


### PR DESCRIPTION
The `lsf.conf` file can specify units other than MB for memory, and
any other large units of scaling, through the `LSF_UNIT_FOR_LIMITS`
variable.

Dask Jobqueue assumes that the units are MB, which is true under
the default setup of LSF, but not always.

* If the admin has changed it to something else in the file.
* If the file does not exist, LSF assumes KB.

This PR adds the ability for users to both specify or allow auto
detection of the unit system through an `lsf_units` kwarg or `lsf-units`
YAML arg.

Auto-detection routine is based on the LSF 9.1.3 docs for where to
look, defaults, and variable names.