### PR TITLE
Drop Python 2 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,19 +9,10 @@ services:
   - docker
 matrix:
   include:
-    - python: "2.7"
-      env:
-        - OS=ubuntu-14.04
-        - JOBQUEUE=sge
     - python: "3.6"
       env:
         - OS=ubuntu-14.04
         - JOBQUEUE=sge
-    - python: "2.7"
-      env:
-        - OS=ubuntu-14.04
-        # JOBQUEUE=none is for tests that do not need a cluster to run
-        - JOBQUEUE=none
     - python: "3.6"
       env:
         - OS=ubuntu-14.04

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ setup(
     description="Easy deployment of Dask Distributed on job queuing systems "
     "such as PBS, Slurm, or SGE.*",
     url="https://github.com/dask/dask-jobqueue",
+    python_requires=">3.5.0",
     license="BSD 3-Clause",
     packages=["dask_jobqueue"],
     include_package_data=True,


### PR DESCRIPTION
Tests will not pass here due to issue resolved in #282 ...and #282 won't pass either without this change (since dropping Py2 support is needed for that). Tests pass with both changes together, see https://travis-ci.org/dask/dask-jobqueue/builds/551671322