### PR TITLE
Add links to @willirath tutorial

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,6 +6,7 @@ Deploy Dask on Job Queueing systems
 Easy deployment of Dask Distributed on job queuing systems such as PBS, Slurm,
 or SGE.  See documentation_ for more information.
 
+
 LICENSE
 -------
 

--- a/README.rst
+++ b/README.rst
@@ -6,6 +6,11 @@ Deploy Dask on Job Queueing systems
 Easy deployment of Dask Distributed on job queuing systems such as PBS, Slurm,
 or SGE.  See documentation_ for more information.
 
+A 4 hour ``dask`` and ``dask-jobqueue`` tutorial was presented in July 2019 by
+`@willirath <https://github.com/willirath>`_. Have a look at the `material
+<https://github.com/willirath/dask_jobqueue_workshop_materials>`_ and the
+videos: `part 1 <https://training.e-cam2020.eu/files/5d244ed9e4b0920ffce61cd4>`_
+and `part 2 <https://training.e-cam2020.eu/files/5d244edde4b0920ffce62116>`_.
 
 LICENSE
 -------

--- a/README.rst
+++ b/README.rst
@@ -6,12 +6,6 @@ Deploy Dask on Job Queueing systems
 Easy deployment of Dask Distributed on job queuing systems such as PBS, Slurm,
 or SGE.  See documentation_ for more information.
 
-A 4 hour ``dask`` and ``dask-jobqueue`` tutorial was presented in July 2019 by
-`@willirath <https://github.com/willirath>`_. Have a look at the `material
-<https://github.com/willirath/dask_jobqueue_workshop_materials>`_ and the
-videos: `part 1 <https://training.e-cam2020.eu/files/5d244ed9e4b0920ffce61cd4>`_
-and `part 2 <https://training.e-cam2020.eu/files/5d244edde4b0920ffce62116>`_.
-
 LICENSE
 -------
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -46,8 +46,8 @@ save resources when not actively computing.
 
 More details
 ------------
-A good entry point to know more about how to use ``dask-jobqueue`` is the the
-:ref:`talks-and-tutorials` section.
+A good entry point to know more about how to use ``dask-jobqueue`` is the
+:ref:`talks-and-tutorials`.
 
 .. toctree::
    :maxdepth: 1

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -44,6 +44,14 @@ save resources when not actively computing.
 
    cluster.adapt(minimum=6, maximum=90)  # auto-scale between 6 and 90 workers
 
+Tutorial
+--------
+
+A 4 hour ``dask`` and ``dask-jobqueue`` tutorial was presented in July 2019 by
+`@willirath <https://github.com/willirath>`_. Have a look at the `material
+<https://github.com/willirath/dask_jobqueue_workshop_materials>`_ and the
+videos: `part 1 <https://training.e-cam2020.eu/files/5d244ed9e4b0920ffce61cd4>`_
+and `part 2 <https://training.e-cam2020.eu/files/5d244edde4b0920ffce62116>`_.
 
 .. toctree::
    :maxdepth: 1

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -44,14 +44,10 @@ save resources when not actively computing.
 
    cluster.adapt(minimum=6, maximum=90)  # auto-scale between 6 and 90 workers
 
-Tutorial
---------
-
-A 4 hour ``dask`` and ``dask-jobqueue`` tutorial was presented in July 2019 by
-`@willirath <https://github.com/willirath>`_. Have a look at the `material
-<https://github.com/willirath/dask_jobqueue_workshop_materials>`_ and the
-videos: `part 1 <https://training.e-cam2020.eu/files/5d244ed9e4b0920ffce61cd4>`_
-and `part 2 <https://training.e-cam2020.eu/files/5d244edde4b0920ffce62116>`_.
+More details
+------------
+A good entry point to know more about how to use ``dask-jobqueue`` is the the
+:ref:`talks-and-tutorials` section.
 
 .. toctree::
    :maxdepth: 1
@@ -59,6 +55,7 @@ and `part 2 <https://training.e-cam2020.eu/files/5d244edde4b0920ffce62116>`_.
 
    install
    interactive
+   talks-and-tutorials
    howitworks
    configuration
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -46,7 +46,7 @@ save resources when not actively computing.
 
 More details
 ------------
-A good entry point to know more about how to use ``dask-jobqueue`` is the
+A good entry point to know more about how to use ``dask-jobqueue`` is
 :ref:`talks-and-tutorials`.
 
 .. toctree::

--- a/docs/source/talks-and-tutorials.rst
+++ b/docs/source/talks-and-tutorials.rst
@@ -1,0 +1,15 @@
+.. _talks-and-tutorials:
+
+Talks & Tutorials
+-----------------
+
+* A 4 hour ``dask`` and ``dask-jobqueue`` tutorial was presented in July 2019
+  by `@willirath <https://github.com/willirath>`_: `Jupyter notebooks
+  <https://github.com/willirath/dask_jobqueue_workshop_materials>`_, videos:
+  `part 1 <https://training.e-cam2020.eu/files/5d244ed9e4b0920ffce61cd4>`_ and
+  `part 2 <https://training.e-cam2020.eu/files/5d244edde4b0920ffce62116>`_.
+* A 30 minute presentation by `andersy005 <https://github.com/andersy005>`_ at
+  Scipy 2019 that features how ``dask-jobqueue`` is used on the NCAR HPC
+  cluster:
+  `slides <https://andersonbanihirwe.dev/talks/dask-jupyter-scipy-2019.html>`_
+  and `video <https://www.youtube.com/watch?v=vhawO8fgD64>`_.


### PR DESCRIPTION
I added them on the docs and in the README. Any comments, let me know!

This is how it looks on the documentation generated locally:

![image](https://user-images.githubusercontent.com/1680079/61277208-00be4e80-a7b2-11e9-9feb-8cf0ec79451e.png).
