### PR TITLE
Fix ClusterManager.dashboard_link

### DIFF
--- a/dask_jobqueue/deploy/cluster_manager.py
+++ b/dask_jobqueue/deploy/cluster_manager.py
@@ -1,7 +1,5 @@
-import dask
 import logging
 import math
-import os
 
 from tornado import gen
 
@@ -12,6 +10,7 @@ from distributed.utils import (
     parse_bytes,
     PeriodicCallback,
     format_bytes,
+    format_dashboard_link,
 )
 
 logger = logging.getLogger(__name__)
@@ -141,10 +140,9 @@ class ClusterManager(object):
 
     @property
     def dashboard_link(self):
-        template = dask.config.get("distributed.dashboard.link")
         host = self.scheduler.address.split("://")[1].split(":")[0]
-        port = self.scheduler.services["bokeh"].port
-        return template.format(host=host, port=port, **os.environ)
+        port = self.scheduler.services["dashboard"].port
+        return format_dashboard_link(host, port)
 
     @gen.coroutine
     def _scale(self, n=None, cores=None, memory=None):
@@ -267,7 +265,7 @@ class ClusterManager(object):
 
         layout = Layout(width="150px")
 
-        if "bokeh" in self.scheduler.services:
+        if "dashboard" in self.scheduler.services:
             link = self.dashboard_link
             link = '<p><b>Dashboard: </b><a href="%s" target="_blank">%s</a></p>\n' % (
                 link,

--- a/dask_jobqueue/tests/test_jobqueue_core.py
+++ b/dask_jobqueue/tests/test_jobqueue_core.py
@@ -85,6 +85,14 @@ def test_repr(Cluster):
         assert "workers=0" in cluster_repr
 
 
+@pytest.mark.parametrize(
+    "Cluster", [PBSCluster, MoabCluster, SLURMCluster, SGECluster, LSFCluster]
+)
+def test_dashboard_link(Cluster):
+    with Cluster(cores=1, memory="1GB") as cluster:
+        assert re.match(r"http://\d+\.\d+\.\d+.\d+:\d+/status", cluster.dashboard_link)
+
+
 def test_forward_ip():
     ip = "127.0.0.1"
     with PBSCluster(


### PR DESCRIPTION
Fixes #288

Specifically, fixes this error in the `dashboard_link` attribute of `ClusterManager`:

```pytb
﻿  File "/miniconda/envs/myenv/lib/python3.7/site-packages/dask_jobqueue/deploy/cluster_manager.py", line 146, in dashboard_link
    port = self.scheduler.services["bokeh"].port
KeyError: 'bokeh'
```