### PR TITLE
Require distributed >= 2.1

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+-r ./requirements.txt
+pre-commit

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-dask>=1.2.0
-distributed>=1.27
+dask>=2
+distributed>=2.1
 docrep
-pre-commit


### PR DESCRIPTION
Following #291.

And split dev requirements into a separate file. As a dask-jobqueue user (rather than developer), you don't need `precommit`.