### PR TITLE
Remove threads from JobQueueCluster arguments.

### DIFF
--- a/dask_jobqueue/core.py
+++ b/dask_jobqueue/core.py
@@ -7,7 +7,6 @@ import re
 import shlex
 import subprocess
 import sys
-import warnings
 from collections import OrderedDict
 from contextlib import contextmanager
 
@@ -22,17 +21,6 @@ from distributed.utils import format_bytes, parse_bytes, tmpfile, get_ip_interfa
 
 logger = logging.getLogger(__name__)
 docstrings = docrep.DocstringProcessor()
-
-
-threads_deprecation_message = """
-The threads keyword has been removed and the memory keyword has changed.
-
-Please specify job size with the following keywords:
-
--  cores: total cores per job, across all processes
--  memory: total memory per job, across all processes
--  processes: number of processes to launch, splitting the quantities above
-""".strip()
 
 
 def _job_id_from_worker_name(name):
@@ -178,7 +166,6 @@ class JobQueueCluster(ClusterManager):
         extra=None,
         env_extra=None,
         log_directory=None,
-        threads=None,
         shebang=None,
         python=sys.executable,
         config_name=None,
@@ -189,9 +176,6 @@ class JobQueueCluster(ClusterManager):
         # This initializer should be considered as Abstract, and never used directly.
         # """
         super(JobQueueCluster, self).__init__()
-
-        if threads is not None:
-            raise ValueError(threads_deprecation_message)
 
         if config_name is None:
             raise NotImplementedError(
@@ -222,9 +206,6 @@ class JobQueueCluster(ClusterManager):
             log_directory = dask.config.get("jobqueue.%s.log-directory" % config_name)
         if shebang is None:
             shebang = dask.config.get("jobqueue.%s.shebang" % config_name)
-
-        if dask.config.get("jobqueue.%s.threads", None):
-            warnings.warn(threads_deprecation_message)
 
         if cores is None:
             raise ValueError(

--- a/dask_jobqueue/tests/test_jobqueue_core.py
+++ b/dask_jobqueue/tests/test_jobqueue_core.py
@@ -26,13 +26,6 @@ def test_errors():
     assert "abstract class" in str(info.value)
 
 
-def test_threads_deprecation():
-    with pytest.raises(ValueError) as info:
-        JobQueueCluster(threads=4)
-
-    assert all(word in str(info.value) for word in ["threads", "core", "processes"])
-
-
 def test_command_template():
     with PBSCluster(cores=2, memory="4GB") as cluster:
         assert (


### PR DESCRIPTION
Trying to use `threads` has raised an informative error message since dask-jobqueue 0.3 (about one year), more precisely this commit: https://github.com/dask/dask-jobqueue/commit/d4d47329eeb5c6216334987032e21e058a6f0cf8.

I think we can safely remove this. Objections more than welcome!

As a reminder: this was when we migrated from `processes` and `threads` (implicitly per dask worker) to `cores` and `processes`.