### PR TITLE
Fix spacing between parameter and parameter type in the API docs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -6,6 +6,8 @@
 # full list see the documentation:
 # http://www.sphinx-doc.org/en/stable/config
 
+from dask_jobqueue import __version__ as version
+
 # -- Path setup --------------------------------------------------------------
 
 # If extensions (or modules to document with autodoc) are in another directory,
@@ -23,8 +25,6 @@ author = u"Dask-jobqueue Development Team"
 project = u"Dask-jobqueue"
 copyright = u"2018, Anaconda, Inc. and contributors"
 
-
-from dask_jobqueue import __version__ as version
 
 # The full version, including alpha/beta/rc tags.
 # release = '0.1.0'
@@ -198,3 +198,13 @@ extlinks = {
     "issue": ("https://github.com/dask/dask-jobqueue/issues/%s", "GH#"),
     "pr": ("https://github.com/dask/dask-jobqueue/pull/%s", "GH#"),
 }
+
+
+# Temporary work-around for spacing problem between parameter and parameter
+# type in the doc, see https://github.com/numpy/numpydoc/issues/215. The bug
+# has been fixed in sphinx (https://github.com/sphinx-doc/sphinx/pull/5976) but
+# through a change in sphinx basic.css except rtd_theme does not use basic.css.
+# In an ideal world, this would get fixed in this PR:
+# https://github.com/readthedocs/sphinx_rtd_theme/pull/747/files
+def setup(app):
+    app.add_stylesheet("basic.css")


### PR DESCRIPTION
This can be quite confusing: e.g. it looks like the parameters are `queuestr` and `projectstr` in this screenshot:
![image](https://user-images.githubusercontent.com/1680079/61943851-a5a00f00-af9c-11e9-98e8-ab99fa09d6a3.png)

* this is related to a change in sphinx 2. This was reported here in numpydoc: https://github.com/numpy/numpydoc/issues/215
* there has been a sphinx fix in https://github.com/sphinx-doc/sphinx/pull/5976
* that sphinx_rtd_theme does not use basic.css. Since dask_sphinx_theme does extends sphinx_rtd_theme we are not benefitting from the sphinx fix. Hopefully this will get merged eventually https://github.com/readthedocs/sphinx_rtd_theme/pull/747

The simplest fix I found was to add `basic.css` through `setup(app)` in `conf.py`

cc @TomAugspurger since i saw he had similar problems in `dask-ml` which he fixed by pinning `sphinx < 2` (except that we can not do that on RTD, which is another story by itself ...)

This is the same screenshot as above from a locally generated doc:
![image](https://user-images.githubusercontent.com/1680079/61944243-89e93880-af9d-11e9-8d3a-aa0dbfa827fb.png)


