### PR TITLE
Removes Python version check for black in CI

### DIFF
--- a/ci/none.sh
+++ b/ci/none.sh
@@ -4,11 +4,7 @@ function jobqueue_before_install {
   # Install miniconda
   ./ci/conda_setup.sh
   export PATH="$HOME/miniconda/bin:$PATH"
-  conda install --yes -c conda-forge python=$TRAVIS_PYTHON_VERSION dask distributed flake8 pytest docrep
-  # black only available for python 3
-  if [[ "$TRAVIS_PYTHON_VERSION" =~ ^[3-9].+ ]]; then
-    pip install black
-  fi
+  conda install --yes -c conda-forge python=$TRAVIS_PYTHON_VERSION dask distributed flake8 black pytest docrep
 }
 
 function jobqueue_install {
@@ -18,9 +14,7 @@ function jobqueue_install {
 
 function jobqueue_script {
   flake8 -j auto dask_jobqueue
-  if [[ "$TRAVIS_PYTHON_VERSION" =~ ^[3-9].+ ]]; then
-     black --exclude versioneer.py --check .
-  fi
+  black --exclude versioneer.py --check .
   pytest --verbose
 }
 


### PR DESCRIPTION
This PR removes a Python 3 version check in `ci/none.sh` for installing / running `black`. This is no longer needed as support for Python 2 has been dropped. 