### PR TITLE
support older HTCondor versions without -file argument and add schedd argument

### DIFF
--- a/dask_jobqueue/htcondor.py
+++ b/dask_jobqueue/htcondor.py
@@ -47,9 +47,11 @@ class HTCondorCluster(JobQueueCluster):
 Environment = "%(quoted_environment)s"
 Arguments = "%(quoted_arguments)s"
 Executable = %(executable)s
+
+Queue
 """.lstrip()
 
-    submit_command = "condor_submit -queue 1 -file"
+    submit_command = "condor_submit"
     cancel_command = "condor_rm"
     job_id_regexp = r"(?P<job_id>\d+\.\d+)"
 

--- a/dask_jobqueue/htcondor.py
+++ b/dask_jobqueue/htcondor.py
@@ -18,6 +18,8 @@ class HTCondorCluster(JobQueueCluster):
     ----------
     disk : str
         Total amount of disk per job
+    schedd : str
+       Submit to the specified condor_schedd
     job_extra : dict
         Extra submit file attributes for the job
     %(JobQueueCluster.parameters)s
@@ -59,7 +61,9 @@ Queue
     # Python (can't find its libs), so we have to go through the shell.
     executable = "/bin/sh"
 
-    def __init__(self, disk=None, job_extra=None, config_name="htcondor", **kwargs):
+    def __init__(
+        self, disk=None, job_extra=None, schedd=None, config_name="htcondor", **kwargs
+    ):
         if disk is None:
             disk = dask.config.get("jobqueue.%s.disk" % config_name)
         if disk is None:
@@ -71,6 +75,8 @@ Queue
             self.job_extra = dask.config.get("jobqueue.%s.job-extra" % config_name, {})
         else:
             self.job_extra = job_extra
+        if schedd is None:
+            schedd = dask.config.get("jobqueue.%s.schedd" % config_name, None)
 
         # Instantiate args and parameters from parent abstract class
         super().__init__(config_name=config_name, **kwargs)
@@ -109,6 +115,9 @@ Queue
             )
         if self.job_extra:
             self.job_header_dict.update(self.job_extra)
+        if schedd:
+            self.submit_command += " -name " + shlex.quote(schedd)
+            self.cancel_command += " -name " + shlex.quote(schedd)
 
     def env_lines_to_dict(self, env_lines):
         """ Convert an array of export statements (what we get from env-extra

--- a/dask_jobqueue/jobqueue.yaml
+++ b/dask_jobqueue/jobqueue.yaml
@@ -155,6 +155,7 @@ jobqueue:
 
     # HTCondor Resource Manager options
     disk: null                  # Total amount of disk per job
+    schedd: null                # Submit to the specified condor_schedd
     extra: []
     env-extra: []
     job-extra: {}               # Extra submit attributes


### PR DESCRIPTION
The  -file argument was introduced in recent versions of HTCondor otherwise the script argument is positional. This adds support for older versions commonly in the wild. (Would only generate a problem if more than one job is queued at once)