### PR TITLE
Default to multiprocesses instead of single process

### DIFF
--- a/dask_jobqueue/core.py
+++ b/dask_jobqueue/core.py
@@ -9,6 +9,7 @@ from collections import OrderedDict
 from contextlib import contextmanager
 
 import dask
+from dask.utils import factors
 import docrep
 from .deploy import ClusterManager
 from distributed import LocalCluster
@@ -185,7 +186,10 @@ class JobQueueCluster(ClusterManager):
         if memory is None:
             memory = dask.config.get("jobqueue.%s.memory" % config_name)
         if processes is None:
-            processes = dask.config.get("jobqueue.%s.processes" % config_name)
+            if cores <= 4:
+                processes = cores
+            else:
+                processes = min(f for f in factors(cores) if f >= math.sqrt(cores))
         if interface is None:
             interface = dask.config.get("jobqueue.%s.interface" % config_name)
         if death_timeout is None:

--- a/dask_jobqueue/core.py
+++ b/dask_jobqueue/core.py
@@ -185,6 +185,13 @@ class JobQueueCluster(ClusterManager):
             cores = dask.config.get("jobqueue.%s.cores" % config_name)
         if memory is None:
             memory = dask.config.get("jobqueue.%s.memory" % config_name)
+        if cores is None or memory is None:
+            raise ValueError(
+                "You must specify how much cores and memory per job you want to use, for example:\n"
+                "cluster = {}(cores={}, memory={!r})".format(
+                    self.__class__.__name__, cores or 8, memory or "24GB"
+                )
+            )
         if processes is None:
             if cores <= 4:
                 processes = cores
@@ -206,14 +213,6 @@ class JobQueueCluster(ClusterManager):
             log_directory = dask.config.get("jobqueue.%s.log-directory" % config_name)
         if shebang is None:
             shebang = dask.config.get("jobqueue.%s.shebang" % config_name)
-
-        if cores is None or memory is None:
-            raise ValueError(
-                "You must specify how much cores and memory per job you want to use, for example:\n"
-                "cluster = {}(cores={}, memory={!r})".format(
-                    self.__class__.__name__, cores or 8, memory or "24GB"
-                )
-            )
 
         # This attribute should be overridden
         self.job_header = None

--- a/dask_jobqueue/jobqueue.yaml
+++ b/dask_jobqueue/jobqueue.yaml
@@ -5,7 +5,6 @@ jobqueue:
     # Dask worker options
     cores: null                 # Total number of cores per job
     memory: null                # Total amount of memory per job
-    processes: 1                # Number of Python processes per job
 
     interface: null             # Network interface to use like eth0 or ib0
     death-timeout: 60           # Number of seconds to wait if a worker can not find a scheduler
@@ -28,7 +27,6 @@ jobqueue:
     # Dask worker options
     cores: null                 # Total number of cores per job
     memory: null                # Total amount of memory per job
-    processes: 1                # Number of Python processes per job
 
     interface: null             # Network interface to use like eth0 or ib0
     death-timeout: 60           # Number of seconds to wait if a worker can not find a scheduler
@@ -51,7 +49,6 @@ jobqueue:
     # Dask worker options
     cores: null                 # Total number of cores per job
     memory: null                # Total amount of memory per job
-    processes: 1                # Number of Python processes per job
 
     interface: null             # Network interface to use like eth0 or ib0
     death-timeout: 60           # Number of seconds to wait if a worker can not find a scheduler
@@ -75,7 +72,6 @@ jobqueue:
     # Dask worker options
     cores: null                 # Total number of cores per job
     memory: null                # Total amount of memory per job
-    processes: 1                # Number of Python processes per job
 
     interface: null             # Network interface to use like eth0 or ib0
     death-timeout: 60           # Number of seconds to wait if a worker can not find a scheduler
@@ -99,7 +95,6 @@ jobqueue:
     # Dask worker options
     cores: null                 # Total number of cores per job
     memory: null                # Total amount of memory per job
-    processes: 1                # Number of Python processes per job
 
     interface: null             # Network interface to use like eth0 or ib0
     death-timeout: 60           # Number of seconds to wait if a worker can not find a scheduler
@@ -122,7 +117,6 @@ jobqueue:
     # Dask worker options
     cores: null                 # Total number of cores per job
     memory: null                # Total amount of memory per job
-    processes: 1                # Number of Python processes per job
 
     interface: null             # Network interface to use like eth0 or ib0
     death-timeout: 60           # Number of seconds to wait if a worker can not find a scheduler
@@ -147,7 +141,6 @@ jobqueue:
     # Dask worker options
     cores: null                 # Total number of cores per job
     memory: null                # Total amount of memory per job
-    processes: 1                # Number of Python processes per job
 
     interface: null             # Network interface to use like eth0 or ib0
     death-timeout: 60           # Number of seconds to wait if a worker can not find a scheduler

--- a/dask_jobqueue/tests/test_jobqueue_core.py
+++ b/dask_jobqueue/tests/test_jobqueue_core.py
@@ -25,7 +25,7 @@ def test_errors():
 
 
 def test_command_template():
-    with PBSCluster(cores=2, memory="4GB") as cluster:
+    with PBSCluster(cores=2, processes=1, memory="4GB") as cluster:
         assert (
             "%s -m distributed.cli.dask_worker" % (sys.executable)
             in cluster._command_template

--- a/dask_jobqueue/tests/test_jobqueue_core.py
+++ b/dask_jobqueue/tests/test_jobqueue_core.py
@@ -189,3 +189,10 @@ def test_cluster_has_cores_and_memory(Cluster):
 
     with pytest.raises(ValueError, match=cls_name + r"cores=4, memory='\d+GB'"):
         Cluster(cores=4)
+
+
+def test_default_workers():
+    """For 6 cores, default is 1 workers with 3 procs, 2 threads/proc"""
+    with PBSCluster(cores=6, memory="4GB") as cluster:
+        assert " --nprocs 3" in cluster._command_template
+        assert " --nthreads 2" in cluster._command_template

--- a/docs/source/configuration-setup.rst
+++ b/docs/source/configuration-setup.rst
@@ -70,9 +70,9 @@ This can be avoided by always using 'GiB' in dask-jobqueue configuration.
 Processes
 ---------
 
-By default Dask will run one Python process per job.  However, you can
-optionally choose to cut up that job into multiple processes using the
-``processes`` configuration value.  This can be advantageous if your
+Dask will, by default, divide each job into a number of processes according
+to the number of cores per job. However, you can overwrite this default value
+using the ``processes`` configuration value.  This can be advantageous if your
 computations are bound by the GIL, but disadvantageous if you plan to
 communicate a lot between processes.  Typically we find that for pure Numpy
 workloads a low number of processes (like one) is best, while for pure Python


### PR DESCRIPTION
Resolving #332 .

This configuration change in JobQueueCluster changes the default processes per job so that they follow the same heuristic as dask (proc=cores for cores <= 4, otherwise it's the smallest factor greater than the square root of cores).

PR also includes modified documentation (though it doesn't explain the heuristic -- perhaps that should be done on dask's docs and we link it?).