### PR TITLE
Update interactive docs

### DIFF
--- a/docs/source/interactive.rst
+++ b/docs/source/interactive.rst
@@ -5,99 +5,138 @@ Dask-jobqueue is most often used for interactive processing using tools like
 IPython or Jupyter notebooks.  This page provides instructions on how to launch
 an interactive Jupyter notebook server and Dask dashboard on your HPC system.
 
+We recommend first doing these steps from a login node (nothing will be
+computationally intensive) but at some point you may want to shift to a compute
+or interactive node.
 
-Using Jupyter
+Install JupyterLab
+------------------
+
+We recommend using JupyterLab, and the `Dask JupyterLab Extension
+<https://github.com/dask/dask-labextension>`_.  This will make it easy to get
+Dask's dashboard through your Jupyter session.
+
+These can be installed with the following steps:
+
+.. code-block:: bash
+
+   # Install JupyterLab and NodeJS (which we'll need to integrate Dask into JLab)
+   conda install jupyterlab nodejs -c conda-forge -y
+
+   # Install server-side pieces of the Dask-JupyterLab extension
+   pip install dask_labextension
+
+   # Integrate Dask-Labextension with Jupyter (requires NodeJS)
+   jupyter labextension install dask-labextension
+
+You can also use ``pip`` rather than ``conda``, but you will have to find some
+other way to install NodeJS.
+
+.. image:: https://github.com/dask/dask-labextension/raw/master/dask.png
+   :width: 50%
+   :alt: Dask JupyterLab Dashboard
+
+Add A Password
+--------------
+
+For security, we recommend adding a password to your Jupyter notebook
+configuration.
+
+.. code-block:: bash
+
+   jupyter notebook password
+
+This is good both for security, and also means that you won't have to copy
+around Jupyter tokens.
+
+
+Start Jupyter
 -------------
 
-It is convenient to run a Jupyter notebook server on the HPC for use with
-dask-jobqueue. You may already have a Jupyterhub instance available on your
-system, which can be used as is. Otherwise, documentation for starting your own
-Jupyter notebook server is available at `Pangeo documentation
-<http://pangeo-data.org/setup_guides/hpc.html#configure-jupyter>`_.
-
-Once Jupyter is installed and configured, using a Jupyter notebook is done by:
-
-- Starting a Jupyter notebook server on the HPC (it is often good practice to
-  run/submit this as a job to an interactive queue, see Pangeo docs for more
-  details).
+When you use Jupyter on your laptop you often just write ``jupyter notebook``
+or ``jupyter lab``.  However, things are a bit different when starting a
+notebook server on a separate machine.  As a first step, the following will
+work:
 
 .. code-block:: bash
 
-   $ jupyter notebook --no-browser --ip=`hostname` --port=8888
+   jupyter lab --no-browser --ip="*" --port 8888
 
-- Reading the output of the command above to get the ip or hostname of your
-  notebook, and use SSH tunneling on your local machine to access the notebook.
-  This must only be done in the probable case where you don't have direct
-  access to the notebook URL from your computer browser.
+Later, once we get SSH tunneling set up, you may want to come back and specify
+a specific IP address or hostname for added security.
+
+
+SSH Tunneling
+-------------
+
+If your personal machine is on the same network as your cluster, then you can
+ignore this step.
+
+If you are on a different network (like your home network), and have to SSH in,
+then it can be difficult to have your local web browser connect to the Jupyter
+server running on the HPC machine.  If your institution doesn't have something
+like `JupyterHub <https://jupyter.org/hub>`_ set up, then the easiest way to
+accomplish this is to use SSH tunneling.
+
+Often a command like the following works:
 
 .. code-block:: bash
 
-   $ ssh -N -L 8888:x.x.x.x:8888 username@hpc_domain
+   ssh -L 8888:login-node-hostname:8888 username@hpc.agency.gov
 
-Now you can go to ``http://localhost:8888`` on your browser to access the
-notebook server.
+Where ...
+
+-  ``login-node-hostname`` is the name of the node from which you are
+    running your Jupyter server, designated ``hostname`` below.
+
+    .. code-block:: bash
+
+      username@hostname$ jupyter lab --no-browser --ip="*" --port 8888
+
+    You might also run ``echo $HOSTNAME`` on that machine as well to see the
+    host name.
+
+-   ``hpc.agency.gov`` is the address that you usually use to
+    ssh into the cluster.
+
+So in a real example this might look like the following:
+
+.. code-block:: bash
+
+    alice@login2.summit $ jupyter lab --no-browser --ip="login2" --port 8888
+    alice@laptop        $ ssh -L 8888:login2:8888 summit.olcf.ornl.gov
+
+Additionally, if port ``8888`` is busy then you may want to choose a different
+port, like ``9999``.  Someone else may be using this port, particularly if they
+are setting up their own Jupyter server on this machine.
+
+You can now visit ``http://localhost:8888`` on your local browser to access the
+Jupyter server.
 
 
 Viewing the Dask Dashboard
 --------------------------
 
-Whether or not you are using dask-jobqueue in Jupyter, IPython or other tools,
-at one point you will want to have access to Dask dashboard. Once you've
-started a cluster and connected a client to it using commands described in
-:ref:`example`), inspecting ``client`` object will give you the Dashboard URL,
-for example ``http://172.16.23.102:8787/status``. The Dask Dashboard may be
-accessible by clicking the link displayed, otherwise, you'll have to use SSH
-tunneling:
+When you start a Dask Jobqueue cluster you also start a Dask dashboard.  This
+dashboard is valuable to help you understand the state of your computation and
+cluster.
 
-.. code-block:: bash
+Typically, the dashboard is served on a separate port from Jupyter, and so can
+be used whether you choose to use Jupyter or not.  If you want to open up a
+connection to see the dashboard you can do so with SSH Tunneling as described
+above.  The dashboard's default port is at ``8787``, and is configurable with
+the ``dashboard_address=`` keyword to the Dask Jobqueue cluster objects.
 
-    # General syntax
-    $ ssh -fN your-login@scheduler-ip-address -L port-number:localhost:port-number
-    # As applied to this example:
-    $ ssh -fN username@172.16.23.102 -L 8787:localhost:8787
+However, Jupyter is also able to proxy the dashboard connection through the
+Jupyter server, allowing you to access the dashboard at
+``http://localhost:8888/proxy/8787/status``.  This requires no additional SSH
+tunneling.  Additionally, if you place this address into the Dask Labextension
+search bar (click the Dask logo icon on the left side of your Jupyter session)
+then you can access the plots directly within Jupyter Lab, rather than open up
+another tab.
 
-Now, you can go to ``http://localhost:8787`` on your browser to view the
-dashboard. Note that you can do SSH tunneling for both Jupyter and Dashboard in
-one command.
-
-A good example of using Jupyter along with dask-jobqueue and the Dashboard is
-available below:
-
-.. raw:: html
-
-   <iframe width="560" height="315"
-           src="https://www.youtube.com/embed/nH_AQo8WdKw?rel=0"
-           frameborder="0" allow="autoplay; encrypted-media"
-           allowfullscreen></iframe>
-
-
-Dask Dashboard with Jupyter
----------------------------
-
-If you are using dask-jobqueue within Jupyter, one user friendly solution to
-see the Dashboard is to use `nbserverproxy
-<https://github.com/jupyterhub/nbserverproxy>`_. As the dashboard HTTP end
-point is launched inside the same node as Jupyter, this is a great solution for
-viewing it without having to do SSH tunneling. You just need to install
-``nbserverproxy`` in the Python environment you use for launching the notebook,
-and activate it as indicated in the docs:
-
-.. code-block:: bash
-
-   pip install nbserverproxy
-   jupyter serverextension enable --py nbserverproxy
-
-Then, once started, the dashboard will be accessible from your notebook URL
-by adding the path ``/proxy/8787/status``, replacing 8787 by any other
-port you use or the dashboard is bind to if needed. Sor for example:
-
- - ``http://localhost:8888/proxy/8787/status`` with the example above
- - ``http://myjupyterhub.org/user/username/proxy/8787/status`` if using
-   JupyterHub
-
-Note that if using Jupyterhub, the service admin should deploy nbserverproxy
-on the environment used for starting singleuser notebook, but each user may
-have to activate the nbserverproxy extension.
+Configuration
+-------------
 
 Finally, you may want to update the dashboard link that is displayed in the
 notebook, shown from Cluster and Client objects. In order to do this,

--- a/docs/source/interactive.rst
+++ b/docs/source/interactive.rst
@@ -9,6 +9,12 @@ We recommend first doing these steps from a login node (nothing will be
 computationally intensive) but at some point you may want to shift to a compute
 or interactive node.
 
+*Note: We also recommend the `JupyterHub <https://jupyter.org/hub>`_ project,
+which allows HPC administrators to offer and control the process described
+in this document automatically.  If you find this process valuable but tedious,
+then you may want to ask your system administrators to support it with
+JupyterHub.*
+
 Install JupyterLab
 ------------------
 
@@ -84,7 +90,8 @@ Often a command like the following works:
 
    ssh -L 8888:login-node-hostname:8888 username@hpc.agency.gov
 
-Where ...
+Where ``login-node-hostname`` and ``username@hpc.agency.gov`` are placeholders
+that you need to fill in:
 
 -  ``login-node-hostname`` is the name of the node from which you are
     running your Jupyter server, designated ``hostname`` below.
@@ -104,7 +111,7 @@ So in a real example this might look like the following:
 .. code-block:: bash
 
     alice@login2.summit $ jupyter lab --no-browser --ip="login2" --port 8888
-    alice@laptop        $ ssh -L 8888:login2:8888 summit.olcf.ornl.gov
+    alice@laptop        $ ssh -L 8888:login2:8888 alice@summit.olcf.ornl.gov
 
 Additionally, if port ``8888`` is busy then you may want to choose a different
 port, like ``9999``.  Someone else may be using this port, particularly if they


### PR DESCRIPTION
This updates our interactive/Jupyter documentation.  We focus a bit more now on JupyterLab, and remove the link to the pangeo docs, which was a bit stale.