### PR TITLE
Update `.scale()` and `.adapt()` docstrings

### DIFF
--- a/dask_jobqueue/core.py
+++ b/dask_jobqueue/core.py
@@ -516,10 +516,10 @@ class JobQueueCluster(SpecCluster):
 
         Parameters
         ----------
-        minimum_cores : int
-           Minimum number of cores for the cluster
-        maximum_cores : int
-           Maximum number of cores for the cluster
+        minimum : int
+           Minimum number of workers to keep around for the cluster
+        maximum : int
+           Maximum number of workers to keep around for the cluster
         minimum_memory : str
            Minimum amount of memory for the cluster
         maximum_memory : str

--- a/dask_jobqueue/core.py
+++ b/dask_jobqueue/core.py
@@ -516,7 +516,14 @@ class JobQueueCluster(SpecCluster):
 
         Parameters
         ----------
-
+        minimum_cores : int
+           Minimum number of cores for the cluster
+        maximum_cores : int
+           Maximum number of cores for the cluster
+        minimum_memory : str
+           Minimum amount of memory for the cluster
+        maximum_memory : str
+           Maximum amount of memory for the cluster
         minimum_jobs : int
            Minimum number of jobs
         maximum_jobs : int

--- a/dask_jobqueue/core.py
+++ b/dask_jobqueue/core.py
@@ -490,6 +490,20 @@ class JobQueueCluster(SpecCluster):
         return self._dummy_job.job_name
 
     def scale(self, n=None, jobs=0, memory=None, cores=None):
+        """ Scale cluster to specified configurations.
+
+        Parameters
+        ----------
+        n : int
+           Target number of workers
+        jobs : int
+           Target number of jobs
+        memory : str
+           Target amount of memory
+        cores : int
+           Target number of cores
+
+        """
         if n is not None:
             jobs = int(math.ceil(n / self._dummy_job.worker_processes))
 
@@ -498,6 +512,23 @@ class JobQueueCluster(SpecCluster):
     def adapt(
         self, *args, minimum_jobs: int = None, maximum_jobs: int = None, **kwargs
     ):
+        """ Scale Dask cluster automatically based on scheduler activity.
+
+        Parameters
+        ----------
+
+        minimum_jobs : int
+           Minimum number of jobs
+        maximum_jobs : int
+           Maximum number of jobs
+        **kwargs :
+           Extra parameters to pass to dask.distributed.Adaptive
+
+        See Also
+        --------
+        dask.distributed.Adaptive : for more keyword arguments
+        """
+
         if minimum_jobs is not None:
             kwargs["minimum"] = minimum_jobs * self._dummy_job.worker_processes
         if maximum_jobs is not None:


### PR DESCRIPTION
Addresses https://github.com/dask/dask-jobqueue/issues/344#issuecomment-537092345

I am not sure what's the right way to include the information from `distributed's SpecCluster` without copying and pasting it into the new docstrings:



- `adapt()`: Updated
```python
In [4]: cluster.adapt?                                                                                          
Signature:
cluster.adapt(
    *args,
    minimum_jobs: int = None,
    maximum_jobs: int = None,
    **kwargs,
)
Docstring:
Scale Dask cluster automatically based on scheduler activity.

Parameters
----------

minimum_jobs : int
   Minimum number of jobs
maximum_jobs : int
   Maximum number of jobs
**kwargs :
   Extra parameters to pass to dask.distributed.Adaptive
```

- `adapt()`: Old version

```python
In [4]: cluster.adapt?                                                                                          
Signature:
cluster.adapt(
    minimum_cores=None,
    maximum_cores=None,
    minimum_memory=None,
    maximum_memory=None,
    **kwargs,
)
Docstring:
Turn on adaptivity
For keyword arguments see dask.distributed.Adaptive
Instead of minimum and maximum parameters which apply to the number of
worker, If Cluster object implements jobqueue_worker_spec attribute, one can
use the following parameters:
Parameters
----------
minimum_cores: int
    Minimum number of cores for the cluster
maximum_cores: int
    Maximum number of cores for the cluster
minimum_memory: str
    Minimum amount of memory for the cluster
maximum_memory: str
    Maximum amount of memory for the cluster
Examples
--------
>>> cluster.adapt(minimum=0, maximum=10, interval='500ms')
>>> cluster.adapt(minimum_cores=24, maximum_cores=96)
>>> cluster.adapt(minimum_memory='60 GB', maximum_memory= '1 TB')
```


- scale
```python
                                                                      
In [3]: cluster.scale?                                                                                          
Signature: cluster.scale(n=None, jobs=0, memory=None, cores=None)
Docstring:
Scale cluster to specified configurations.

Parameters
----------
n : int
   Target number of workers
jobs : int
   Target number of jobs
memory : str
   Target amount of memory
cores : int
   Target number of cores
```