### PR TITLE
WIP: Add unified test suite infrastructure

### DIFF
--- a/dask_jobqueue/tests/test_cluster.py
+++ b/dask_jobqueue/tests/test_cluster.py
@@ -172,6 +172,7 @@ async def check_adaptive_cores_mem(cluster, client):
         asyncio.sleep(0.100)
         assert time() < start + QUEUE_WAIT
 
+
 @pytest.mark.parametrize("cluster_cls", cluster_params)
 @pytest.mark.parametrize("check", all_checks())
 @pytest.mark.asyncio

--- a/dask_jobqueue/tests/test_cluster.py
+++ b/dask_jobqueue/tests/test_cluster.py
@@ -8,17 +8,23 @@ import dask_jobqueue
 from dask_jobqueue.tests import QUEUE_WAIT
 from dask_jobqueue.local import LocalCluster
 
-cluster_classes = [getattr(dask_jobqueue, attr) for attr in dir(dask_jobqueue) if attr.endswith('Cluster')]
-cluster_names = [cls.__name__.replace('Cluster', '').lower() for cls in cluster_classes]
+cluster_classes = [
+    getattr(dask_jobqueue, attr)
+    for attr in dir(dask_jobqueue)
+    if attr.endswith("Cluster")
+]
+cluster_names = [cls.__name__.replace("Cluster", "").lower() for cls in cluster_classes]
 
-cluster_params = [pytest.param(cluster_cls, marks=[pytest.mark.env(cluster_name)])
-                  for cluster_cls, cluster_name in zip(cluster_classes, cluster_names)]
+cluster_params = [
+    pytest.param(cluster_cls, marks=[pytest.mark.env(cluster_name)])
+    for cluster_cls, cluster_name in zip(cluster_classes, cluster_names)
+]
 cluster_params.append(pytest.param(LocalCluster))
 
 
 def all_checks():
-    checks = [obj for name, obj in globals().items() if name.startswith('check_')]
-    print('checks:', checks)
+    checks = [obj for name, obj in globals().items() if name.startswith("check_")]
+    print("checks:", checks)
     return checks
 
 

--- a/dask_jobqueue/tests/test_cluster.py
+++ b/dask_jobqueue/tests/test_cluster.py
@@ -1,0 +1,183 @@
+import pytest
+import asyncio
+from time import time
+
+from dask.distributed import Client
+
+import dask_jobqueue
+from dask_jobqueue.tests import QUEUE_WAIT
+from dask_jobqueue.local import LocalCluster
+
+cluster_classes = [getattr(dask_jobqueue, attr) for attr in dir(dask_jobqueue) if attr.endswith('Cluster')]
+cluster_names = [cls.__name__.replace('Cluster', '').lower() for cls in cluster_classes]
+
+cluster_params = [pytest.param(cluster_cls, marks=[pytest.mark.env(cluster_name)])
+                  for cluster_cls, cluster_name in zip(cluster_classes, cluster_names)]
+cluster_params.append(pytest.param(LocalCluster))
+
+
+def all_checks():
+    checks = [obj for name, obj in globals().items() if name.startswith('check_')]
+    print('checks:', checks)
+    return checks
+
+
+async def check_basic(cluster, client):
+    cluster.scale(2)
+
+    start = time()
+    while not client.scheduler_info()["workers"]:
+        await asyncio.sleep(0.100)
+        assert time() < start + QUEUE_WAIT
+
+    future = client.submit(lambda x: x + 1, 10)
+    assert future.result(QUEUE_WAIT) == 11
+    assert len(client.scheduler_info()["workers"]) > 0
+
+    workers = list(client.scheduler_info()["workers"].values())
+    w = workers[0]
+    assert w["memory_limit"] == 2e9 / 4
+    assert w["nthreads"] == 2
+
+    cluster.scale(0)
+
+    start = time()
+    while client.scheduler_info()["workers"]:
+        asyncio.sleep(0.100)
+        assert time() < start + QUEUE_WAIT
+
+    assert not cluster.workers and not cluster.worker_spec
+
+
+async def check_scale_cores_memory(cluster, client):
+    cluster.scale(cores=2)
+    client.wait_for_workers(1)
+
+    future = client.submit(lambda x: x + 1, 10)
+    assert future.result(QUEUE_WAIT) == 11
+    assert cluster.workers
+
+    workers = list(client.scheduler_info()["workers"].values())
+    w = workers[0]
+    assert w["memory_limit"] == 2e9
+    assert w["nthreads"] == 2
+
+    cluster.scale(memory="0GB")
+
+    start = time()
+    while client.scheduler_info()["workers"]:
+        asyncio.sleep(0.100)
+        assert time() < start + QUEUE_WAIT
+
+    assert not cluster.workers
+
+
+async def check_basic_scale_edge_cases(cluster, client):
+    cluster.scale(2)
+    cluster.scale(0)
+
+    # Wait to see what happens
+    asyncio.sleep(0.2)
+    start = time()
+    while cluster.workers:
+        asyncio.sleep(0.1)
+        assert time() < start + QUEUE_WAIT
+
+    assert not cluster.workers
+
+
+async def check_scale_grouped(cluster, client):
+    cluster.scale(4)  # Start 2 jobs
+
+    start = time()
+
+    while len(list(client.scheduler_info()["workers"].values())) != 4:
+        asyncio.sleep(0.100)
+        assert time() < start + QUEUE_WAIT
+
+    future = client.submit(lambda x: x + 1, 10)
+    assert future.result(QUEUE_WAIT) == 11
+    # assert cluster.running_jobs
+
+    workers = list(client.scheduler_info()["workers"].values())
+    w = workers[0]
+    assert w["memory_limit"] == 1e9
+    assert w["nthreads"] == 1
+    assert len(workers) == 4
+
+    cluster.scale(1)  # Should leave 2 workers, 1 job
+
+    start = time()
+    while len(client.scheduler_info()["workers"]) != 2:
+        asyncio.sleep(0.100)
+        assert time() < start + QUEUE_WAIT
+
+    cluster.scale(0)
+
+    start = time()
+
+    assert not cluster.worker_spec
+    while len(client.scheduler_info()["workers"]) != 0:
+        asyncio.sleep(0.100)
+        assert time() < start + QUEUE_WAIT
+
+
+async def check_adaptive(cluster, client):
+    cluster.adapt()
+    with Client(cluster) as client:
+        future = client.submit(lambda x: x + 1, 10)
+
+        start = time()
+        client.wait_for_workers(1)
+
+        assert future.result(QUEUE_WAIT) == 11
+
+        del future
+
+        start = time()
+        while client.scheduler_info()["workers"]:
+            asyncio.sleep(0.100)
+            assert time() < start + QUEUE_WAIT
+
+
+async def check_adaptive_grouped(cluster, client):
+    cluster.adapt(minimum=1)  # at least 1 worker
+    client.wait_for_workers(1)
+
+    future = client.submit(lambda x: x + 1, 10)
+    assert future.result(QUEUE_WAIT) == 11
+
+    start = time()
+    processes = cluster._dummy_job.worker_processes
+    while len(client.scheduler_info()["workers"]) != processes:
+        asyncio.sleep(0.1)
+        assert time() < start + QUEUE_WAIT
+
+
+async def check_adaptive_cores_mem(cluster, client):
+    cluster.adapt(minimum_cores=0, maximum_memory="4GB")
+    future = client.submit(lambda x: x + 1, 10)
+    assert future.result(QUEUE_WAIT) == 11
+
+    start = time()
+    processes = cluster._dummy_job.worker_processes
+    while len(client.scheduler_info()["workers"]) != processes:
+        asyncio.sleep(0.1)
+        assert time() < start + QUEUE_WAIT
+
+    del future
+
+    start = time()
+    while cluster.workers:
+        asyncio.sleep(0.100)
+        assert time() < start + QUEUE_WAIT
+
+@pytest.mark.parametrize("cluster_cls", cluster_params)
+@pytest.mark.parametrize("check", all_checks())
+@pytest.mark.asyncio
+async def test(cluster_cls, check):
+    async with cluster_cls(
+        cores=6, memory="6GB", processes=2, asynchronous=True
+    ) as cluster:
+        async with Client(cluster, asynchronous=True) as client:
+            check(cluster, client)

--- a/dask_jobqueue/tests/test_htcondor.py
+++ b/dask_jobqueue/tests/test_htcondor.py
@@ -1,8 +1,4 @@
 import sys
-from time import sleep, time
-
-import pytest
-from distributed import Client
 
 import dask
 

--- a/dask_jobqueue/tests/test_htcondor.py
+++ b/dask_jobqueue/tests/test_htcondor.py
@@ -50,35 +50,6 @@ def test_job_script():
         assert "--nprocs 2" in job_script
 
 
-@pytest.mark.env("htcondor")
-def test_basic(loop):
-    with HTCondorCluster(cores=1, memory="100MB", disk="100MB", loop=loop) as cluster:
-        with Client(cluster) as client:
-
-            cluster.scale(2)
-
-            start = time()
-            while not (cluster.pending_jobs or cluster.running_jobs):
-                sleep(0.100)
-                assert time() < start + QUEUE_WAIT
-
-            future = client.submit(lambda x: x + 1, 10)
-            assert future.result(QUEUE_WAIT) == 11
-            assert cluster.running_jobs
-
-            workers = list(client.scheduler_info()["workers"].values())
-            w = workers[0]
-            assert w["memory_limit"] == 1e8
-            assert w["nthreads"] == 1
-
-            cluster.scale(0)
-
-            start = time()
-            while cluster.running_jobs:
-                sleep(0.100)
-                assert time() < start + QUEUE_WAIT
-
-
 def test_config_name_htcondor_takes_custom_config():
     conf = {
         "cores": 1,

--- a/dask_jobqueue/tests/test_job.py
+++ b/dask_jobqueue/tests/test_job.py
@@ -24,7 +24,12 @@ from dask.distributed import Scheduler, Client
 
 import pytest
 
+# General TODO for this module: should I get rid of most stuff or at least
+# improve test_cluster.py taking inspiration from this? I guess I still want to
+# test JobQueueCluster(job=...) maybe at least in a very simple way but at the
+# same time I feel like this is duplicating the testing of FooCluster classes
 
+# TODO: move to common test
 def test_basic():
     job = PBSJob(scheduler="127.0.0.1:12345", cores=1, memory="1 GB")
     assert "127.0.0.1:12345" in job.job_script()
@@ -174,6 +179,7 @@ async def test_nprocs_scale():
             assert len(cluster.worker_spec) == 1
 
 
+# TODO: this should move to test_cluster.py ?
 @pytest.mark.parametrize("Cluster", all_clusters)
 def test_docstring_cluster(Cluster):
     assert "cores :" in Cluster.__doc__

--- a/dask_jobqueue/tests/test_job.py
+++ b/dask_jobqueue/tests/test_job.py
@@ -29,6 +29,7 @@ import pytest
 # test JobQueueCluster(job=...) maybe at least in a very simple way but at the
 # same time I feel like this is duplicating the testing of FooCluster classes
 
+
 # TODO: move to common test
 def test_basic():
     job = PBSJob(scheduler="127.0.0.1:12345", cores=1, memory="1 GB")

--- a/dask_jobqueue/tests/test_lsf.py
+++ b/dask_jobqueue/tests/test_lsf.py
@@ -3,16 +3,12 @@ from shutil import rmtree
 import sys
 from textwrap import dedent
 import tempfile
-from time import sleep, time
 
 import dask
 import pytest
-from dask.distributed import Client
 from distributed.utils import parse_bytes
 
 from dask_jobqueue import LSFCluster, lsf
-
-from . import QUEUE_WAIT
 
 
 def test_header():
@@ -177,6 +173,7 @@ def test_config_name_lsf_takes_custom_config():
     with dask.config.set({"jobqueue.lsf-config-name": conf}):
         with LSFCluster(config_name="lsf-config-name") as cluster:
             assert cluster.job_name == "myname"
+
 
 # TODO common test
 def test_informative_errors():

--- a/dask_jobqueue/tests/test_pbs.py
+++ b/dask_jobqueue/tests/test_pbs.py
@@ -1,13 +1,9 @@
 import sys
-from time import sleep, time
 
 import dask
 import pytest
-from dask.distributed import Client
 
 from dask_jobqueue import MoabCluster, PBSCluster
-
-from . import QUEUE_WAIT
 
 
 @pytest.mark.parametrize("Cluster", [PBSCluster, MoabCluster])
@@ -107,6 +103,7 @@ def test_config(loop):
             assert "00:02:00" in cluster.job_script()
             assert "--local-directory /foo" in cluster.job_script()
 
+
 # TODO make it a common test
 def test_config_name_pbs_takes_custom_config():
     conf = {
@@ -134,6 +131,7 @@ def test_config_name_pbs_takes_custom_config():
     with dask.config.set({"jobqueue.pbs-config-name": conf}):
         with PBSCluster(config_name="pbs-config-name") as cluster:
             assert cluster.job_name == "myname"
+
 
 # TODO common test
 def test_informative_errors():

--- a/dask_jobqueue/tests/test_slurm.py
+++ b/dask_jobqueue/tests/test_slurm.py
@@ -108,66 +108,7 @@ def test_job_script():
         assert "--nthreads 2 --nprocs 4 --memory-limit 7.00GB" in job_script
 
 
-@pytest.mark.env("slurm")
-def test_basic(loop):
-    with SLURMCluster(
-        walltime="00:02:00",
-        cores=2,
-        processes=1,
-        memory="2GB",
-        # job_extra=["-D /"],
-        loop=loop,
-    ) as cluster:
-        with Client(cluster) as client:
-
-            cluster.scale(2)
-
-            start = time()
-            client.wait_for_workers(2)
-
-            future = client.submit(lambda x: x + 1, 10)
-            assert future.result(QUEUE_WAIT) == 11
-
-            workers = list(client.scheduler_info()["workers"].values())
-            w = workers[0]
-            assert w["memory_limit"] == 2e9
-            assert w["nthreads"] == 2
-
-            cluster.scale(0)
-
-            start = time()
-            while client.scheduler_info()["workers"]:
-                sleep(0.100)
-                assert time() < start + QUEUE_WAIT
-
-
-@pytest.mark.env("slurm")
-def test_adaptive(loop):
-    with SLURMCluster(
-        walltime="00:02:00",
-        cores=2,
-        processes=1,
-        memory="2GB",
-        # job_extra=["-D /"],
-        loop=loop,
-    ) as cluster:
-        cluster.adapt()
-        with Client(cluster) as client:
-            future = client.submit(lambda x: x + 1, 10)
-
-            start = time()
-            client.wait_for_workers(1)
-
-            assert future.result(QUEUE_WAIT) == 11
-
-            del future
-
-            start = time()
-            while client.scheduler_info()["workers"]:
-                sleep(0.100)
-                assert time() < start + QUEUE_WAIT
-
-
+# TODO I should turn that into a common test as well
 def test_config_name_slurm_takes_custom_config():
     conf = {
         "queue": "myqueue",

--- a/dask_jobqueue/tests/test_slurm.py
+++ b/dask_jobqueue/tests/test_slurm.py
@@ -1,14 +1,8 @@
 import sys
-from time import sleep, time
-
-import pytest
-from distributed import Client
 
 import dask
 
 from dask_jobqueue import SLURMCluster
-
-from . import QUEUE_WAIT
 
 
 def test_header():


### PR DESCRIPTION
Closes #8.

The idea is that there is a lot of tests that we would want to run for all the `FooCluster` classes. At the moment there is some duplication in `test_sge.py`, `test_slurm.py`, etc ... (e.g. `test_basic`, `test_adaptive`, ...) and some cluster-generic functionality are only tested for some clusters (e.g. only `test_pbs.py` has some tests for scaling with "grouped workers" e.g. `test_scale_grouped`).

This is quite WIP at the moment but if you have some early feed-back about the approach don't hesitate! The main thing to look at is `test/test_cluster.py`. The way it currently works is you add a `check_whatever(cluster, client)` function in `tests/test_cluster.py` and there is a parametrized `test` function at the end that will run the tests for all the `check_*` functions and all the `FooCluster` classes. 

This is somewhat influenced by how the "common tests" are structured in scikit-learn (this tests some common properties of all the scikit-learn estimators, for example that fitting twice with the same data gives the same result) and there may be a more clever way of doing it.

A few things I want to look at still (besides cleaning up all the TODO):
- [ ] it would be great to differentiate `check` functions that need a real cluster (basically that need to do `.scale`). This could be based on a naming convention e.g. `check_real_cluster` vs `check` or be in different files `test_real_cluster.py` vs `test_cluster.py` (but then there would be some duplication). Maybe a clever pytest trick would do it (can we add pytest marks to normal functions and detect that) or even use a simple decorator that adds an attributed to the function and we can test this attribute in the parmetrized `test`.
- [ ] some documentation in the module and/or in a contributing guide 
- [ ] potentially other things that I will add later