### PR TITLE
LSF: Accept use_stdin in the constructor

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -5,6 +5,8 @@ from distributed.utils_test import loop  # noqa: F401
 
 import pytest
 
+import dask_jobqueue.lsf
+
 
 def pytest_addoption(parser):
     parser.addoption(
@@ -27,3 +29,18 @@ def pytest_runtest_setup(item):
     if envnames:
         if item.config.getoption("-E") not in envnames:
             pytest.skip("test requires env in %r" % envnames)
+
+
+@pytest.fixture(autouse=True)
+def mock_lsf_version(monkeypatch, request):
+    # Monkey-patch lsf_version() UNLESS the 'lsf' environment is selected.
+    # In that case, the real lsf_version() function should work.
+    markers = list(request.node.iter_markers())
+    if any("lsf" in marker.args for marker in markers):
+        return
+
+    try:
+        dask_jobqueue.lsf.lsf_version()
+    except OSError:
+        # Provide a fake implementation of lsf_version()
+        monkeypatch.setattr(dask_jobqueue.lsf, "lsf_version", lambda: "10")

--- a/dask_jobqueue/jobqueue.yaml
+++ b/dask_jobqueue/jobqueue.yaml
@@ -140,7 +140,7 @@ jobqueue:
     job-extra: []
     log-directory: null
     lsf-units: null
-    use-stdin: null
+    use-stdin: null             # (bool) How jobs are launched, i.e. 'bsub jobscript.sh' or 'bsub < jobscript.sh'
 
   htcondor:
     name: dask-worker


### PR DESCRIPTION
Right now, all LSF options can be specified either in the config OR in the constructor arguments, except the new `use-stdin` option (introduced in #347). Unlike all the others, that option may only be specified in the config (not the constructor).

I don't see why we'd want `use-stdin` to be different from all the other LSF options, so this PR allows the user to pass `use_stdin` to the `LSFCluster` constructor if she wants to.  (As usual, the config is used if no value was passed in the constructor.)

```python
cluster = LSFCluster(cores=15, memory='25GB',
                     use_stdin=True) # <-- now allowed
```

Side note: I suspect this new setting will be needed by many, if not most, LSF users, so I added some verbose documentation for it.

FWIW, I tested these changes on my LSF cluster, and they work as expected.