### PR TITLE
Improve error message when cores or memory is not specified in cluster class

### DIFF
--- a/dask_jobqueue/core.py
+++ b/dask_jobqueue/core.py
@@ -182,10 +182,12 @@ class Job(ProcessInterface, abc.ABC):
             shebang = dask.config.get("jobqueue.%s.shebang" % config_name)
 
         if cores is None or memory is None:
+            job_class_name = self.__class__.__name__
+            cluster_class_name = job_class_name.replace("Job", "Cluster")
             raise ValueError(
                 "You must specify how much cores and memory per job you want to use, for example:\n"
                 "cluster = {}(cores={}, memory={!r})".format(
-                    self.__class__.__name__, cores or 8, memory or "24GB"
+                    cluster_class_name, cores or 8, memory or "24GB"
                 )
             )
 

--- a/dask_jobqueue/tests/test_jobqueue_core.py
+++ b/dask_jobqueue/tests/test_jobqueue_core.py
@@ -198,11 +198,12 @@ def test_jobqueue_cluster_call(tmpdir):
     [PBSCluster, MoabCluster, SLURMCluster, SGECluster, LSFCluster, OARCluster],
 )
 def test_cluster_has_cores_and_memory(Cluster):
-    with pytest.raises(ValueError, match=r"cores=\d, memory='\d+GB'"):
+    base_regex = r"{}.+".format(Cluster.__name__)
+    with pytest.raises(ValueError, match=base_regex + r"cores=\d, memory='\d+GB'"):
         Cluster()
 
-    with pytest.raises(ValueError, match=r"cores=\d, memory='1GB'"):
+    with pytest.raises(ValueError, match=base_regex + r"cores=\d, memory='1GB'"):
         Cluster(memory="1GB")
 
-    with pytest.raises(ValueError, match=r"cores=4, memory='\d+GB'"):
+    with pytest.raises(ValueError, match=base_regex + r"cores=4, memory='\d+GB'"):
         Cluster(cores=4)


### PR DESCRIPTION
Small side-effect of #307.

```py
from dask_jobqueue.sge import SGECluster 
cluster = SGECluster() 
```

The error is confusing because it mentions `SGEJob` rather than `SGECluster` ...

```

ValueError: You must specify how much cores and memory per job you want to use, for example:
cluster = SGEJob(cores=8, memory='24GB')
```