### PR TITLE
Simplify default config_name and job_cls mechanism

### DIFF
--- a/dask_jobqueue/core.py
+++ b/dask_jobqueue/core.py
@@ -143,11 +143,10 @@ class Job(ProcessInterface, abc.ABC):
 
         super().__init__()
 
-        if config_name is None:
-            config_name = getattr(type(self), "config_name")
+        # TODO move if cores is None exception here too ...
         if config_name is None:
             raise ValueError(
-                "Looks like you are trying to create a class that inherits from dask_jobqueue.core.Job. "
+                "Looks like you are trying to create a class that inherits from dask_jobqueue.core.JobQueueCluster. "
                 "If that is the case, you need to:\n"
                 "- set the 'config_name' class variable to a non-None value\n"
                 "- create a section in jobqueue.yaml with the value of 'config_name'\n"

--- a/dask_jobqueue/htcondor.py
+++ b/dask_jobqueue/htcondor.py
@@ -31,28 +31,29 @@ Queue
     # Python (can't find its libs), so we have to go through the shell.
     executable = "/bin/sh"
 
-    def __init__(
-        self, *args, disk=None, job_extra=None, config_name="htcondor", **kwargs
-    ):
+    config_name = "htcondor"
+
+    def __init__(self, *args, disk=None, job_extra=None, config_name=None, **kwargs):
+        super().__init__(*args, config_name=config_name, **kwargs)
+
         if disk is None:
-            disk = dask.config.get("jobqueue.%s.disk" % config_name)
+            disk = dask.config.get("jobqueue.%s.disk" % self.config_name)
         if disk is None:
             raise ValueError(
                 "You must specify how much disk to use per job like ``disk='1 GB'``"
             )
         self.worker_disk = parse_bytes(disk)
         if job_extra is None:
-            self.job_extra = dask.config.get("jobqueue.%s.job-extra" % config_name, {})
+            self.job_extra = dask.config.get(
+                "jobqueue.%s.job-extra" % self.config_name, {}
+            )
         else:
             self.job_extra = job_extra
-
-        # Instantiate args and parameters from parent abstract class
-        super().__init__(*args, config_name=config_name, **kwargs)
 
         env_extra = kwargs.get("env_extra", None)
         if env_extra is None:
             env_extra = dask.config.get(
-                "jobqueue.%s.env-extra" % config_name, default=[]
+                "jobqueue.%s.env-extra" % self.config_name, default=[]
             )
         self.env_dict = self.env_lines_to_dict(env_extra)
         self.env_dict["JOB_ID"] = "$F(MY.JobId)"

--- a/dask_jobqueue/local.py
+++ b/dask_jobqueue/local.py
@@ -32,7 +32,7 @@ class LocalJob(Job):
         resource_spec=None,
         walltime=None,
         job_extra=None,
-        config_name="local",
+        config_name=None,
         **kwargs
     ):
         # Instantiate args and parameters from parent abstract class

--- a/dask_jobqueue/lsf.py
+++ b/dask_jobqueue/lsf.py
@@ -17,6 +17,7 @@ logger = logging.getLogger(__name__)
 class LSFJob(Job):
     submit_command = "bsub"
     cancel_command = "bkill"
+    config_name = "lsf"
 
     def __init__(
         self,
@@ -28,33 +29,32 @@ class LSFJob(Job):
         walltime=None,
         job_extra=None,
         lsf_units=None,
-        config_name="lsf",
+        config_name=None,
         use_stdin=None,
         **kwargs
     ):
+        super().__init__(*args, config_name=config_name, **kwargs)
+
         if queue is None:
-            queue = dask.config.get("jobqueue.%s.queue" % config_name)
+            queue = dask.config.get("jobqueue.%s.queue" % self.config_name)
         if project is None:
-            project = dask.config.get("jobqueue.%s.project" % config_name)
+            project = dask.config.get("jobqueue.%s.project" % self.config_name)
         if ncpus is None:
-            ncpus = dask.config.get("jobqueue.%s.ncpus" % config_name)
+            ncpus = dask.config.get("jobqueue.%s.ncpus" % self.config_name)
         if mem is None:
-            mem = dask.config.get("jobqueue.%s.mem" % config_name)
+            mem = dask.config.get("jobqueue.%s.mem" % self.config_name)
         if walltime is None:
-            walltime = dask.config.get("jobqueue.%s.walltime" % config_name)
+            walltime = dask.config.get("jobqueue.%s.walltime" % self.config_name)
         if job_extra is None:
-            job_extra = dask.config.get("jobqueue.%s.job-extra" % config_name)
+            job_extra = dask.config.get("jobqueue.%s.job-extra" % self.config_name)
         if lsf_units is None:
-            lsf_units = dask.config.get("jobqueue.%s.lsf-units" % config_name)
+            lsf_units = dask.config.get("jobqueue.%s.lsf-units" % self.config_name)
 
         if use_stdin is None:
-            use_stdin = dask.config.get("jobqueue.%s.use-stdin" % config_name)
+            use_stdin = dask.config.get("jobqueue.%s.use-stdin" % self.config_name)
         if use_stdin is None:
             use_stdin = lsf_version() < "10"
         self.use_stdin = use_stdin
-
-        # Instantiate args and parameters from parent abstract class
-        super().__init__(*args, config_name=config_name, **kwargs)
 
         header_lines = []
         # LSF header build

--- a/dask_jobqueue/oar.py
+++ b/dask_jobqueue/oar.py
@@ -14,6 +14,7 @@ class OARJob(Job):
     submit_command = "oarsub"
     cancel_command = "oardel"
     job_id_regexp = r"OAR_JOB_ID=(?P<job_id>\d+)"
+    config_name = "oar"
 
     def __init__(
         self,
@@ -23,21 +24,23 @@ class OARJob(Job):
         resource_spec=None,
         walltime=None,
         job_extra=None,
-        config_name="oar",
+        config_name=None,
         **kwargs
     ):
-        if queue is None:
-            queue = dask.config.get("jobqueue.%s.queue" % config_name)
-        if project is None:
-            project = dask.config.get("jobqueue.%s.project" % config_name)
-        if resource_spec is None:
-            resource_spec = dask.config.get("jobqueue.%s.resource-spec" % config_name)
-        if walltime is None:
-            walltime = dask.config.get("jobqueue.%s.walltime" % config_name)
-        if job_extra is None:
-            job_extra = dask.config.get("jobqueue.%s.job-extra" % config_name)
-
         super().__init__(*args, config_name=config_name, **kwargs)
+
+        if queue is None:
+            queue = dask.config.get("jobqueue.%s.queue" % self.config_name)
+        if project is None:
+            project = dask.config.get("jobqueue.%s.project" % self.config_name)
+        if resource_spec is None:
+            resource_spec = dask.config.get(
+                "jobqueue.%s.resource-spec" % self.config_name
+            )
+        if walltime is None:
+            walltime = dask.config.get("jobqueue.%s.walltime" % self.config_name)
+        if job_extra is None:
+            job_extra = dask.config.get("jobqueue.%s.job-extra" % self.config_name)
 
         header_lines = []
         if self.job_name is not None:

--- a/dask_jobqueue/pbs.py
+++ b/dask_jobqueue/pbs.py
@@ -47,24 +47,25 @@ class PBSJob(Job):
         resource_spec=None,
         walltime=None,
         job_extra=None,
-        config_name="pbs",
+        config_name=None,
         **kwargs
     ):
+        super().__init__(*args, config_name=config_name, **kwargs)
+
         if queue is None:
-            queue = dask.config.get("jobqueue.%s.queue" % config_name)
+            queue = dask.config.get("jobqueue.%s.queue" % self.config_name)
         if resource_spec is None:
-            resource_spec = dask.config.get("jobqueue.%s.resource-spec" % config_name)
+            resource_spec = dask.config.get(
+                "jobqueue.%s.resource-spec" % self.config_name
+            )
         if walltime is None:
-            walltime = dask.config.get("jobqueue.%s.walltime" % config_name)
+            walltime = dask.config.get("jobqueue.%s.walltime" % self.config_name)
         if job_extra is None:
-            job_extra = dask.config.get("jobqueue.%s.job-extra" % config_name)
+            job_extra = dask.config.get("jobqueue.%s.job-extra" % self.config_name)
         if project is None:
             project = dask.config.get(
-                "jobqueue.%s.project" % config_name
+                "jobqueue.%s.project" % self.config_name
             ) or os.environ.get("PBS_ACCOUNT")
-
-        # Instantiate args and parameters from parent abstract class
-        super().__init__(*args, config_name=config_name, **kwargs)
 
         # Try to find a project name from environment variable
         project = project or os.environ.get("PBS_ACCOUNT")

--- a/dask_jobqueue/sge.py
+++ b/dask_jobqueue/sge.py
@@ -10,6 +10,7 @@ logger = logging.getLogger(__name__)
 class SGEJob(Job):
     submit_command = "qsub"
     cancel_command = "qdel"
+    config_name = "sge"
 
     def __init__(
         self,
@@ -19,21 +20,23 @@ class SGEJob(Job):
         resource_spec=None,
         walltime=None,
         job_extra=None,
-        config_name="sge",
+        config_name=None,
         **kwargs
     ):
-        if queue is None:
-            queue = dask.config.get("jobqueue.%s.queue" % config_name)
-        if project is None:
-            project = dask.config.get("jobqueue.%s.project" % config_name)
-        if resource_spec is None:
-            resource_spec = dask.config.get("jobqueue.%s.resource-spec" % config_name)
-        if walltime is None:
-            walltime = dask.config.get("jobqueue.%s.walltime" % config_name)
-        if job_extra is None:
-            job_extra = dask.config.get("jobqueue.%s.job-extra" % config_name)
-
         super().__init__(*args, config_name=config_name, **kwargs)
+
+        if queue is None:
+            queue = dask.config.get("jobqueue.%s.queue" % self.config_name)
+        if project is None:
+            project = dask.config.get("jobqueue.%s.project" % self.config_name)
+        if resource_spec is None:
+            resource_spec = dask.config.get(
+                "jobqueue.%s.resource-spec" % self.config_name
+            )
+        if walltime is None:
+            walltime = dask.config.get("jobqueue.%s.walltime" % self.config_name)
+        if job_extra is None:
+            job_extra = dask.config.get("jobqueue.%s.job-extra" % self.config_name)
 
         header_lines = []
         if self.job_name is not None:

--- a/dask_jobqueue/sge.py
+++ b/dask_jobqueue/sge.py
@@ -114,4 +114,3 @@ class SGECluster(JobQueueCluster):
         job=job_parameters, cluster=cluster_parameters
     )
     job_cls = SGEJob
-    config_name = "sge"

--- a/dask_jobqueue/slurm.py
+++ b/dask_jobqueue/slurm.py
@@ -12,6 +12,7 @@ class SLURMJob(Job):
     # Override class variables
     submit_command = "sbatch"
     cancel_command = "scancel"
+    config_name = "slurm"
 
     def __init__(
         self,
@@ -22,23 +23,23 @@ class SLURMJob(Job):
         job_cpu=None,
         job_mem=None,
         job_extra=None,
-        config_name="slurm",
+        config_name=None,
         **kwargs
     ):
-        if queue is None:
-            queue = dask.config.get("jobqueue.%s.queue" % config_name)
-        if project is None:
-            project = dask.config.get("jobqueue.%s.project" % config_name)
-        if walltime is None:
-            walltime = dask.config.get("jobqueue.%s.walltime" % config_name)
-        if job_cpu is None:
-            job_cpu = dask.config.get("jobqueue.%s.job-cpu" % config_name)
-        if job_mem is None:
-            job_mem = dask.config.get("jobqueue.%s.job-mem" % config_name)
-        if job_extra is None:
-            job_extra = dask.config.get("jobqueue.%s.job-extra" % config_name)
-
         super().__init__(*args, config_name=config_name, **kwargs)
+
+        if queue is None:
+            queue = dask.config.get("jobqueue.%s.queue" % self.config_name)
+        if project is None:
+            project = dask.config.get("jobqueue.%s.project" % self.config_name)
+        if walltime is None:
+            walltime = dask.config.get("jobqueue.%s.walltime" % self.config_name)
+        if job_cpu is None:
+            job_cpu = dask.config.get("jobqueue.%s.job-cpu" % self.config_name)
+        if job_mem is None:
+            job_mem = dask.config.get("jobqueue.%s.job-mem" % self.config_name)
+        if job_extra is None:
+            job_extra = dask.config.get("jobqueue.%s.job-extra" % self.config_name)
 
         header_lines = []
         # SLURM header build

--- a/dask_jobqueue/tests/test_jobqueue_core.py
+++ b/dask_jobqueue/tests/test_jobqueue_core.py
@@ -20,7 +20,8 @@ from dask_jobqueue.sge import SGEJob
 
 
 def test_errors():
-    with pytest.raises(ValueError, match="Job type.*job_cls="):
+    match = re.compile("Job type.*job_cls=", flags=re.DOTALL)
+    with pytest.raises(ValueError, match=match):
         JobQueueCluster(cores=4)
 
 

--- a/dask_jobqueue/tests/test_jobqueue_core.py
+++ b/dask_jobqueue/tests/test_jobqueue_core.py
@@ -3,8 +3,11 @@ import shutil
 import socket
 import sys
 import re
+import psutil
 
 import pytest
+
+import dask
 
 from dask_jobqueue import (
     JobQueueCluster,
@@ -208,3 +211,12 @@ def test_cluster_has_cores_and_memory(Cluster):
 
     with pytest.raises(ValueError, match=base_regex + r"cores=4, memory='\d+GB'"):
         Cluster(cores=4)
+
+
+@pytest.mark.asyncio
+async def test_config_interface():
+    net_if_addrs = psutil.net_if_addrs()
+    interface = list(net_if_addrs.keys())[0]
+    with dask.config.set({"jobqueue.pbs.interface": interface}):
+        cluster = PBSCluster(cores=1, memory="2GB", asynchronous=True)
+        assert interface in str(cluster.scheduler_spec)

--- a/dask_jobqueue/tests/test_jobqueue_core.py
+++ b/dask_jobqueue/tests/test_jobqueue_core.py
@@ -19,6 +19,8 @@ from dask_jobqueue import (
     OARCluster,
 )
 
+from dask_jobqueue.local import LocalCluster
+
 from dask_jobqueue.sge import SGEJob
 
 
@@ -217,6 +219,10 @@ def test_cluster_has_cores_and_memory(Cluster):
 async def test_config_interface():
     net_if_addrs = psutil.net_if_addrs()
     interface = list(net_if_addrs.keys())[0]
-    with dask.config.set({"jobqueue.pbs.interface": interface}):
-        cluster = PBSCluster(cores=1, memory="2GB", asynchronous=True)
-        assert interface in str(cluster.scheduler_spec)
+    with dask.config.set({"jobqueue.local.interface": interface}):
+        cluster = LocalCluster(cores=1, memory="2GB", asynchronous=True)
+        await cluster
+        expected = "'interface': {!r}".format(interface)
+        assert expected in str(cluster.scheduler_spec)
+        cluster.scale(1)
+        assert expected in str(cluster.worker_spec)


### PR DESCRIPTION
Supersedes and closes #361.
Fixes #358.

The idea is to use a similar mechanism for `config_name` and `job_cls` (a class variable is the default value, but it can also be passed as a parameter).

There are also some cleaning up of a few quirks that remained after #307.