### PR TITLE
Add scheduler_options to pass scheduler-specific parameters

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,19 +9,19 @@ services:
   - docker
 matrix:
   include:
-    # - python: "3.6"
-    #   env:
-    #     - OS=ubuntu-14.04
-    #     - JOBQUEUE=sge
-    # - python: "3.6"
-    #   env:
-    #     - OS=ubuntu-14.04
-    #     # JOBQUEUE=none is for tests that do not need a cluster to run
-    #     - JOBQUEUE=none
-    # - python: "3.6"
-    #   env:
-    #     - OS=ubuntu-14.04
-    #     - JOBQUEUE=pbs
+    - python: "3.6"
+      env:
+        - OS=ubuntu-14.04
+        - JOBQUEUE=sge
+    - python: "3.6"
+      env:
+        - OS=ubuntu-14.04
+        # JOBQUEUE=none is for tests that do not need a cluster to run
+        - JOBQUEUE=none
+    - python: "3.6"
+      env:
+        - OS=ubuntu-14.04
+        - JOBQUEUE=pbs
     - python: "3.6"
       env:
         - OS=ubuntu-14.04

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,19 +9,19 @@ services:
   - docker
 matrix:
   include:
-    - python: "3.6"
-      env:
-        - OS=ubuntu-14.04
-        - JOBQUEUE=sge
-    - python: "3.6"
-      env:
-        - OS=ubuntu-14.04
-        # JOBQUEUE=none is for tests that do not need a cluster to run
-        - JOBQUEUE=none
-    - python: "3.6"
-      env:
-        - OS=ubuntu-14.04
-        - JOBQUEUE=pbs
+    # - python: "3.6"
+    #   env:
+    #     - OS=ubuntu-14.04
+    #     - JOBQUEUE=sge
+    # - python: "3.6"
+    #   env:
+    #     - OS=ubuntu-14.04
+    #     # JOBQUEUE=none is for tests that do not need a cluster to run
+    #     - JOBQUEUE=none
+    # - python: "3.6"
+    #   env:
+    #     - OS=ubuntu-14.04
+    #     - JOBQUEUE=pbs
     - python: "3.6"
       env:
         - OS=ubuntu-14.04

--- a/ci/slurm.sh
+++ b/ci/slurm.sh
@@ -18,7 +18,7 @@ function jobqueue_install {
 }
 
 function jobqueue_script {
-    docker exec -it slurmctld /bin/bash -c "pytest /dask-jobqueue/dask_jobqueue --verbose -E slurm -s"
+    docker exec -it slurmctld /bin/bash -c "pytest /dask-jobqueue/dask_jobqueue --verbose -E slurm -s -k different"
 }
 
 function jobqueue_after_script {

--- a/ci/slurm.sh
+++ b/ci/slurm.sh
@@ -11,13 +11,26 @@ function jobqueue_before_install {
 
     docker ps -a
     docker images
+    debug
+}
+
+function debug {
+    for c in slurmctld c1 c2; do
+        echo '------------------------------------------------------------'
+        echo $c
+        docker exec $c ip addr
+        docker exec -it $c python -c 'import psutil; print(psutil.net_if_addrs().keys())'
+        echo '------------------------------------------------------------'
+    done
 }
 
 function jobqueue_install {
+    debug
     docker exec -it slurmctld /bin/bash -c "cd /dask-jobqueue; pip install -e ."
 }
 
 function jobqueue_script {
+    debug
     docker exec -it slurmctld /bin/bash -c "pytest /dask-jobqueue/dask_jobqueue --verbose -E slurm -s -k different"
 }
 

--- a/ci/slurm.sh
+++ b/ci/slurm.sh
@@ -11,27 +11,24 @@ function jobqueue_before_install {
 
     docker ps -a
     docker images
-    debug
+    show_network_interfaces
 }
 
-function debug {
+function show_network_interfaces {
     for c in slurmctld c1 c2; do
         echo '------------------------------------------------------------'
-        echo $c
-        docker exec $c ip addr
+        echo docker container: $c
         docker exec -it $c python -c 'import psutil; print(psutil.net_if_addrs().keys())'
         echo '------------------------------------------------------------'
     done
 }
 
 function jobqueue_install {
-    debug
     docker exec -it slurmctld /bin/bash -c "cd /dask-jobqueue; pip install -e ."
 }
 
 function jobqueue_script {
-    debug
-    docker exec -it slurmctld /bin/bash -c "pytest /dask-jobqueue/dask_jobqueue --verbose -E slurm -s -k different"
+    docker exec -it slurmctld /bin/bash -c "pytest /dask-jobqueue/dask_jobqueue --verbose -E slurm -s"
 }
 
 function jobqueue_after_script {

--- a/ci/slurm/Dockerfile
+++ b/ci/slurm/Dockerfile
@@ -1,5 +1,7 @@
 FROM giovtorres/slurm-docker-cluster
 
+RUN yum install -y iproute
+
 RUN curl -o miniconda.sh https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh && \
     bash miniconda.sh -f -b -p /opt/anaconda && \
     /opt/anaconda/bin/conda clean -tipy && \

--- a/ci/slurm/Dockerfile
+++ b/ci/slurm/Dockerfile
@@ -7,8 +7,8 @@ RUN curl -o miniconda.sh https://repo.continuum.io/miniconda/Miniconda3-latest-L
     /opt/anaconda/bin/conda clean -tipy && \
     rm -f miniconda.sh
 ENV PATH /opt/anaconda/bin:$PATH
-RUN conda install --yes -c conda-forge python=3.7 dask distributed flake8 pytest pytest-asyncio
-# RUN pip install git+https://github.com/dask/distributed --upgrade --no-deps
+RUN conda install --yes -c conda-forge python=3.6 dask distributed flake8 pytest pytest-asyncio
+RUN pip install git+https://github.com/dask/distributed --upgrade --no-deps
 
 ENV LC_ALL en_US.UTF-8
 

--- a/ci/slurm/Dockerfile
+++ b/ci/slurm/Dockerfile
@@ -7,8 +7,8 @@ RUN curl -o miniconda.sh https://repo.continuum.io/miniconda/Miniconda3-latest-L
     /opt/anaconda/bin/conda clean -tipy && \
     rm -f miniconda.sh
 ENV PATH /opt/anaconda/bin:$PATH
-RUN conda install --yes -c conda-forge python=3.6 dask distributed flake8 pytest pytest-asyncio
-RUN pip install git+https://github.com/dask/distributed --upgrade --no-deps
+RUN conda install --yes -c conda-forge python=3.7 dask distributed flake8 pytest pytest-asyncio
+# RUN pip install git+https://github.com/dask/distributed --upgrade --no-deps
 
 ENV LC_ALL en_US.UTF-8
 

--- a/ci/slurm/docker-compose.yml
+++ b/ci/slurm/docker-compose.yml
@@ -12,6 +12,8 @@ services:
       MYSQL_PASSWORD: password
     volumes:
       - var_lib_mysql:/var/lib/mysql
+    networks:
+      common-network:
 
   slurmdbd:
     build: .
@@ -26,6 +28,8 @@ services:
       - "6819"
     depends_on:
       - mysql
+    networks:
+      common-network:
 
   slurmctld:
     build: .
@@ -42,6 +46,11 @@ services:
       - "6817"
     depends_on:
       - "slurmdbd"
+    networks:
+      common-network:
+        ipv4_address: 172.16.238.10
+    cap_add:
+      - NET_ADMIN
 
   c1:
     build: .
@@ -57,6 +66,11 @@ services:
       - "6818"
     depends_on:
       - "slurmctld"
+    networks:
+      common-network:
+        ipv4_address: 172.16.238.11
+    cap_add:
+      - NET_ADMIN
 
   c2:
     build: .
@@ -72,6 +86,11 @@ services:
       - "6818"
     depends_on:
       - "slurmctld"
+    networks:
+      common-network:
+        ipv4_address: 172.16.238.12
+    cap_add:
+      - NET_ADMIN
 
 volumes:
   etc_munge:
@@ -79,3 +98,12 @@ volumes:
   slurm_jobdir:
   var_lib_mysql:
   var_log_slurm:
+
+networks:
+  common-network:
+    driver: bridge
+    ipam:
+      driver: default
+      config:
+        - subnet: 172.16.238.0/24
+          gateway: 172.16.238.254

--- a/ci/slurm/docker-compose.yml
+++ b/ci/slurm/docker-compose.yml
@@ -48,7 +48,7 @@ services:
       - "slurmdbd"
     networks:
       common-network:
-        ipv4_address: 172.16.238.10
+        ipv4_address: 10.1.1.10
     cap_add:
       - NET_ADMIN
 
@@ -68,7 +68,7 @@ services:
       - "slurmctld"
     networks:
       common-network:
-        ipv4_address: 172.16.238.11
+        ipv4_address: 10.1.1.11
     cap_add:
       - NET_ADMIN
 
@@ -88,7 +88,7 @@ services:
       - "slurmctld"
     networks:
       common-network:
-        ipv4_address: 172.16.238.12
+        ipv4_address: 10.1.1.12
     cap_add:
       - NET_ADMIN
 
@@ -105,5 +105,4 @@ networks:
     ipam:
       driver: default
       config:
-        - subnet: 172.16.238.0/24
-          gateway: 172.16.238.254
+        - subnet: 10.1.1.0/24

--- a/ci/slurm/start-slurm.sh
+++ b/ci/slurm/start-slurm.sh
@@ -12,6 +12,6 @@ echo "SLURM properly configured"
 # On some clusters the login node does not have the same interface as the
 # compute nodes. The next three lines allow to test this edge case by adding
 # separate interfaces on the worker and on the scheduler nodes.
-docker exec slurmctld ip addr add 172.16.238.20/24 dev eth0 label eth0:scheduler
-docker exec c1 ip addr add 172.16.238.21/24 dev eth0 label eth0:worker
-docker exec c2 ip addr add 172.16.238.22/24 dev eth0 label eth0:worker
+docker exec slurmctld ip addr add 10.1.1.20/24 dev eth0 label eth0:scheduler
+docker exec c1 ip addr add 10.1.1.21/24 dev eth0 label eth0:worker
+docker exec c2 ip addr add 10.1.1.22/24 dev eth0 label eth0:worker

--- a/ci/slurm/start-slurm.sh
+++ b/ci/slurm/start-slurm.sh
@@ -9,6 +9,10 @@ docker exec slurmctld ip addr add 172.16.238.20/24 dev eth0 label eth0:scheduler
 docker exec c1 ip addr add 172.16.238.21/24 dev eth0 label eth0:worker
 docker exec c2 ip addr add 172.16.238.22/24 dev eth0 label eth0:worker
 
+docker exec slurmctld ip addr
+docker exec c1 ip addr
+docker exec c2 ip addr
+
 while [ `./register_cluster.sh 2>&1 | grep "sacctmgr: error" | wc -l` -ne 0 ]
   do
     echo "Waiting for SLURM cluster to become ready";

--- a/ci/slurm/start-slurm.sh
+++ b/ci/slurm/start-slurm.sh
@@ -1,6 +1,14 @@
 #!/bin/bash
 
 docker-compose up --build -d
+
+# On some clusters the login node does not have the same interface as the
+# compute nodes. The next three lines allow to test this edge case by adding
+# separate interfaces on the worker and on the scheduler nodes.
+docker exec slurmctld ip addr add 172.16.238.20/24 dev eth0 label eth0:scheduler
+docker exec c1 ip addr add 172.16.238.21/24 dev eth0 label eth0:worker
+docker exec c2 ip addr add 172.16.238.22/24 dev eth0 label eth0:worker
+
 while [ `./register_cluster.sh 2>&1 | grep "sacctmgr: error" | wc -l` -ne 0 ]
   do
     echo "Waiting for SLURM cluster to become ready";

--- a/ci/slurm/start-slurm.sh
+++ b/ci/slurm/start-slurm.sh
@@ -9,13 +9,6 @@ docker exec slurmctld ip addr add 172.16.238.20/24 dev eth0 label eth0:scheduler
 docker exec c1 ip addr add 172.16.238.21/24 dev eth0 label eth0:worker
 docker exec c2 ip addr add 172.16.238.22/24 dev eth0 label eth0:worker
 
-for c in slurmctld c1 c2; do
-    echo $i
-    docker exec $c ip addr
-    docker exec -it $c python -c 'import psutil; print(psutil.net_if_addrs().keys())'
-    echo '------------------------------------------------------------'
-done
-
 while [ `./register_cluster.sh 2>&1 | grep "sacctmgr: error" | wc -l` -ne 0 ]
   do
     echo "Waiting for SLURM cluster to become ready";

--- a/ci/slurm/start-slurm.sh
+++ b/ci/slurm/start-slurm.sh
@@ -2,16 +2,16 @@
 
 docker-compose up --build -d
 
-# On some clusters the login node does not have the same interface as the
-# compute nodes. The next three lines allow to test this edge case by adding
-# separate interfaces on the worker and on the scheduler nodes.
-docker exec slurmctld ip addr add 172.16.238.20/24 dev eth0 label eth0:scheduler
-docker exec c1 ip addr add 172.16.238.21/24 dev eth0 label eth0:worker
-docker exec c2 ip addr add 172.16.238.22/24 dev eth0 label eth0:worker
-
 while [ `./register_cluster.sh 2>&1 | grep "sacctmgr: error" | wc -l` -ne 0 ]
   do
     echo "Waiting for SLURM cluster to become ready";
     sleep 2
   done
 echo "SLURM properly configured"
+
+# On some clusters the login node does not have the same interface as the
+# compute nodes. The next three lines allow to test this edge case by adding
+# separate interfaces on the worker and on the scheduler nodes.
+docker exec slurmctld ip addr add 172.16.238.20/24 dev eth0 label eth0:scheduler
+docker exec c1 ip addr add 172.16.238.21/24 dev eth0 label eth0:worker
+docker exec c2 ip addr add 172.16.238.22/24 dev eth0 label eth0:worker

--- a/ci/slurm/start-slurm.sh
+++ b/ci/slurm/start-slurm.sh
@@ -9,9 +9,12 @@ docker exec slurmctld ip addr add 172.16.238.20/24 dev eth0 label eth0:scheduler
 docker exec c1 ip addr add 172.16.238.21/24 dev eth0 label eth0:worker
 docker exec c2 ip addr add 172.16.238.22/24 dev eth0 label eth0:worker
 
-docker exec slurmctld ip addr
-docker exec c1 ip addr
-docker exec c2 ip addr
+for c in slurmctld c1 c2; do
+    echo $i
+    docker exec $c ip addr
+    docker exec -it $c python -c 'import psutil; print(psutil.net_if_addrs().keys())'
+    echo '------------------------------------------------------------'
+done
 
 while [ `./register_cluster.sh 2>&1 | grep "sacctmgr: error" | wc -l` -ne 0 ]
   do

--- a/dask_jobqueue/core.py
+++ b/dask_jobqueue/core.py
@@ -15,7 +15,7 @@ from dask.utils import ignoring
 from distributed.deploy.spec import ProcessInterface, SpecCluster
 from distributed.deploy.local import nprocesses_nthreads
 from distributed.scheduler import Scheduler
-from distributed.utils import format_bytes, parse_bytes, tmpfile, get_ip_interface
+from distributed.utils import format_bytes, parse_bytes, tmpfile
 
 logger = logging.getLogger(__name__)
 
@@ -206,9 +206,6 @@ class Job(ProcessInterface, abc.ABC):
 
         if interface:
             extra = extra + ["--interface", interface]
-            kwargs.setdefault("host", get_ip_interface(interface))
-        else:
-            kwargs.setdefault("host", "")
 
         # Keep information on process, cores, and memory, for use in subclasses
         self.worker_memory = parse_bytes(memory) if memory is not None else None

--- a/dask_jobqueue/core.py
+++ b/dask_jobqueue/core.py
@@ -30,7 +30,11 @@ job_parameters = """
         By default, ``process ~= sqrt(cores)`` so that the number of processes
         and the number of threads per process is roughly the same.
     interface : str
-        Network interface like 'eth0' or 'ib0'.
+        Network interface like 'eth0' or 'ib0'. This will be used both for the
+        Dask scheduler and the Dask workers interface. If you need a different
+        interface for the Dask scheduler you can pass it through
+        the ``scheduler_options`` argument:
+        ``interface=your_worker_interface, scheduler_options={'interface': your_scheduler_interface}``.
     nanny : bool
         Whether or not to start a nanny process
     local_directory : str

--- a/dask_jobqueue/tests/test_jobqueue_core.py
+++ b/dask_jobqueue/tests/test_jobqueue_core.py
@@ -84,7 +84,7 @@ def test_forward_ip():
         cores=8,
         memory="28GB",
         name="dask-worker",
-        host=ip,
+        scheduler_options={"host": ip},
     ) as cluster:
         assert cluster.scheduler.ip == ip
 
@@ -268,3 +268,19 @@ def test_default_number_of_worker_processes(Cluster):
     with Cluster(cores=6, memory="4GB") as cluster:
         assert " --nprocs 3" in cluster.job_script()
         assert " --nthreads 2" in cluster.job_script()
+
+
+@pytest.mark.parametrize(
+    "Cluster",
+    [PBSCluster, MoabCluster, SLURMCluster, SGECluster, LSFCluster, OARCluster],
+)
+def test_scheduler_options(Cluster):
+    net_if_addrs = psutil.net_if_addrs()
+    interface = list(net_if_addrs.keys())[0]
+    port = 8804
+    with Cluster(
+        cores=1, memory="1GB", scheduler_options={"interface": interface, "port": port}
+    ) as cluster:
+        scheduler_options = cluster.scheduler_spec["options"]
+        assert scheduler_options["interface"] == interface
+        assert scheduler_options["port"] == port

--- a/dask_jobqueue/tests/test_slurm.py
+++ b/dask_jobqueue/tests/test_slurm.py
@@ -197,6 +197,13 @@ def test_config_name_slurm_takes_custom_config():
 
 @pytest.mark.env("slurm")
 def test_different_interfaces_on_scheduler_and_workers(loop):
+    import socket
+
+    print()
+    print("host:", socket.gethostname())
+    import psutil
+
+    print("interfaces:", psutil.net_if_addrs().keys())
     with SLURMCluster(
         walltime="00:02:00",
         cores=1,

--- a/dask_jobqueue/tests/test_slurm.py
+++ b/dask_jobqueue/tests/test_slurm.py
@@ -197,13 +197,6 @@ def test_config_name_slurm_takes_custom_config():
 
 @pytest.mark.env("slurm")
 def test_different_interfaces_on_scheduler_and_workers(loop):
-    import socket
-
-    print()
-    print("host:", socket.gethostname())
-    import psutil
-
-    print("interfaces:", psutil.net_if_addrs().keys())
     with SLURMCluster(
         walltime="00:02:00",
         cores=1,

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -15,6 +15,10 @@ Development version
   process and only threads, i.e. ``proccesses=1``, ``threads_per_process=cores``.
 - fix bug (forgotten async def) in ``OARCluster._submit_job`` (:pr:`380`).
 - ``LSFCluster``: switch to ``use_stdin=True`` (:pr:`388`).
+- all cluster classes: add ``scheduler_options`` allows to pass parameters to
+  the Dask scheduler. For example ``scheduler_options={'interface': 'eth0',
+  dashboard_addresses=':12435')`` (:pr:`384`). Breaking change: ``port`` and
+  ``dashboard_addresses`` has to be passed through ``scheduler_options``.
 
 0.7.0 / 2019-10-09
 ------------------

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -17,8 +17,9 @@ Development version
 - ``LSFCluster``: switch to ``use_stdin=True`` (:pr:`388`).
 - all cluster classes: add ``scheduler_options`` allows to pass parameters to
   the Dask scheduler. For example ``scheduler_options={'interface': 'eth0',
-  dashboard_addresses=':12435')`` (:pr:`384`). Breaking change: ``port`` and
-  ``dashboard_addresses`` has to be passed through ``scheduler_options``.
+  dashboard_addresses=':12435')`` (:pr:`384`). Breaking change: using ``port``
+  or ``dashboard_addresses`` arguments raises an error. They have to be passed
+  through ``scheduler_options``.
 
 0.7.0 / 2019-10-09
 ------------------

--- a/docs/source/interactive.rst
+++ b/docs/source/interactive.rst
@@ -129,10 +129,12 @@ dashboard is valuable to help you understand the state of your computation and
 cluster.
 
 Typically, the dashboard is served on a separate port from Jupyter, and so can
-be used whether you choose to use Jupyter or not.  If you want to open up a
+be used whether you choose to use Jupyter or not. If you want to open up a
 connection to see the dashboard you can do so with SSH Tunneling as described
-above.  The dashboard's default port is at ``8787``, and is configurable with
-the ``dashboard_address=`` keyword to the Dask Jobqueue cluster objects.
+above. The dashboard's default port is at ``8787``, and is configurable by
+using the ``scheduler_options`` parameter in the Dask Jobqueue cluster object.
+For example ``scheduler_options={'dashboard_address': ':12435'}`` would use
+12435 for the web dasboard port.
 
 However, Jupyter is also able to proxy the dashboard connection through the
 Jupyter server, allowing you to access the dashboard at


### PR DESCRIPTION
fix #355 (regression in 0.7 where `scheduler port` was ignored), fix #382 (different interfaces on scheduler and workers).