### PR TITLE
Switch to use_stdin=True by default for LSFCluster.

### DIFF
--- a/dask_jobqueue/jobqueue.yaml
+++ b/dask_jobqueue/jobqueue.yaml
@@ -140,7 +140,7 @@ jobqueue:
     job-extra: []
     log-directory: null
     lsf-units: null
-    use-stdin: null             # (bool) How jobs are launched, i.e. 'bsub jobscript.sh' or 'bsub < jobscript.sh'
+    use-stdin: True             # (bool) How jobs are launched, i.e. 'bsub jobscript.sh' or 'bsub < jobscript.sh'
 
   htcondor:
     name: dask-worker

--- a/dask_jobqueue/lsf.py
+++ b/dask_jobqueue/lsf.py
@@ -52,8 +52,6 @@ class LSFJob(Job):
 
         if use_stdin is None:
             use_stdin = dask.config.get("jobqueue.%s.use-stdin" % self.config_name)
-        if use_stdin is None:
-            use_stdin = lsf_version() < "10"
         self.use_stdin = use_stdin
 
         header_lines = []

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -14,6 +14,7 @@ Development version
   of threads per process is roughly the same. Old default was to use one
   process and only threads, i.e. ``proccesses=1``, ``threads_per_process=cores``.
 - fix bug (forgotten async def) in ``OARCluster._submit_job`` (:pr:`380`).
+- ``LSFCluster``: switch to ``use_stdin=False`` (:pr:`388`).
 
 0.7.0 / 2019-10-09
 ------------------

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -14,7 +14,7 @@ Development version
   of threads per process is roughly the same. Old default was to use one
   process and only threads, i.e. ``proccesses=1``, ``threads_per_process=cores``.
 - fix bug (forgotten async def) in ``OARCluster._submit_job`` (:pr:`380`).
-- ``LSFCluster``: switch to ``use_stdin=False`` (:pr:`388`).
+- ``LSFCluster``: switch to ``use_stdin=True`` (:pr:`388`).
 
 0.7.0 / 2019-10-09
 ------------------


### PR DESCRIPTION
Fix #372.

cc @d-v-b, @stuarteberg.

Note: this kind of config file defaults change, needs an action from the user, either:
- edit `jobqueue.yaml` by hand
- delete `jobqueue.yaml` if you have nothing useful there and it will be recreated from scratch with the new defaults

I believe this is good enough but let me know if you have any comments.