### PR TITLE
[WIP] Scheduler in Cluster

### DIFF
--- a/dask_jobqueue/slurm.py
+++ b/dask_jobqueue/slurm.py
@@ -24,9 +24,11 @@ class SLURMJob(Job):
         job_mem=None,
         job_extra=None,
         config_name=None,
+        deploy_mode='local',
+        deploy_command='distributed.cli.dask_worker',
         **kwargs
     ):
-        super().__init__(*args, config_name=config_name, **kwargs)
+        super().__init__(*args, deploy_mode=deploy_mode, deploy_command=deploy_command, config_name=config_name, **kwargs)
 
         if queue is None:
             queue = dask.config.get("jobqueue.%s.queue" % self.config_name)


### PR DESCRIPTION
This is really hacky and ongoing work to move the scheduler into the cluster.  By doing this we _should_ be able to more easily run other communication protocols for the dask cluster such as UCX:

Current idea for how this might look:
```python
cluster = SLURMCluster(
    deploy_mode="remote",
    cores=1,
    memory="5GB",
    protocol="ucx",
    env_extra=[
        "UCX_MEMTYPE_CACHE=n",
        "UCX_SOCKADDR_TLS_PRIORITY=sockcm",
        "UCX_TLS=tcp,cuda_copy,sockcm,cuda_ipc",
    ],
)


cluster.scale(1)
client = Client(cluster)
```