### PR TITLE
MNT: small CI cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
-dist: trusty
-sudo: required
+dist: xenial
 
 notifications:
   email: false
@@ -11,25 +10,17 @@ matrix:
   include:
     - python: "3.6"
       env:
-        - OS=ubuntu-14.04
         - JOBQUEUE=sge
     - python: "3.6"
       env:
-        - OS=ubuntu-14.04
         # JOBQUEUE=none is for tests that do not need a cluster to run
         - JOBQUEUE=none
     - python: "3.6"
       env:
-        - OS=ubuntu-14.04
         - JOBQUEUE=pbs
     - python: "3.6"
       env:
-        - OS=ubuntu-14.04
         - JOBQUEUE=slurm
-
-env:
-  global:
-    - DOCKER_COMPOSE_VERSION=1.6.0
 
 before_install:
   - set -e

--- a/ci/none.sh
+++ b/ci/none.sh
@@ -5,7 +5,6 @@ function jobqueue_before_install {
   ./ci/conda_setup.sh
   export PATH="$HOME/miniconda/bin:$PATH"
   conda install --yes -c conda-forge python=$TRAVIS_PYTHON_VERSION dask distributed flake8 black pytest pytest-asyncio
-  pip install git+https://github.com/dask/distributed@master --upgrade --no-deps
 }
 
 function jobqueue_install {

--- a/ci/pbs/Dockerfile
+++ b/ci/pbs/Dockerfile
@@ -31,7 +31,6 @@ RUN curl -o miniconda.sh https://repo.continuum.io/miniconda/Miniconda3-latest-L
     /opt/anaconda/bin/conda clean -tipy && \
     rm -f miniconda.sh
 RUN conda install --yes -c conda-forge python=3.6 dask distributed flake8 pytest pytest-asyncio
-RUN pip install git+https://github.com/dask/distributed --upgrade --no-deps
 
 # Copy entrypoint and other needed scripts
 COPY ./*.sh /

--- a/ci/sge/Dockerfile-master
+++ b/ci/sge/Dockerfile-master
@@ -11,7 +11,6 @@ RUN curl -o miniconda.sh https://repo.continuum.io/miniconda/Miniconda3-latest-L
 ENV PATH /opt/anaconda/bin:$PATH
 ARG PYTHON_VERSION
 RUN conda install -c conda-forge python=$PYTHON_VERSION dask distributed pytest pytest-asyncio && conda clean -tipy
-RUN pip install git+https://github.com/dask/distributed --upgrade --no-deps
 
 COPY ./*.sh /
 COPY ./*.txt /

--- a/ci/sge/Dockerfile-slave
+++ b/ci/sge/Dockerfile-slave
@@ -11,7 +11,6 @@ RUN curl -o miniconda.sh https://repo.continuum.io/miniconda/Miniconda3-latest-L
 ENV PATH /opt/anaconda/bin:$PATH
 ARG PYTHON_VERSION
 RUN conda install -c conda-forge python=$PYTHON_VERSION dask distributed pytest pytest-asyncio && conda clean -tipy
-RUN pip install git+https://github.com/dask/distributed --upgrade --no-deps
 
 COPY ./setup-slave.sh /
 COPY ./*.sh /

--- a/ci/slurm/Dockerfile
+++ b/ci/slurm/Dockerfile
@@ -6,7 +6,6 @@ RUN curl -o miniconda.sh https://repo.continuum.io/miniconda/Miniconda3-latest-L
     rm -f miniconda.sh
 ENV PATH /opt/anaconda/bin:$PATH
 RUN conda install --yes -c conda-forge python=3.6 dask distributed flake8 pytest pytest-asyncio
-RUN pip install git+https://github.com/dask/distributed --upgrade --no-deps
 
 ENV LC_ALL en_US.UTF-8
 


### PR DESCRIPTION
- switch to xenial (current Travis default). This should not have any impact since most of our tests run inside docker
- sudo is true by default, see https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration for more details
- DOCKER_COMPOSE_VERSION and OS env variables are not used
- use latest Dask release rather than development version