### PR TITLE
Remove unused JOB_ID variable.

### DIFF
--- a/dask_jobqueue/htcondor.py
+++ b/dask_jobqueue/htcondor.py
@@ -56,7 +56,6 @@ Queue
                 "jobqueue.%s.env-extra" % self.config_name, default=[]
             )
         self.env_dict = self.env_lines_to_dict(env_extra)
-        self.env_dict["JOB_ID"] = "$F(MY.JobId)"
 
         self.job_header_dict = {
             "MY.DaskWorkerName": '"htcondor--$F(MY.JobId)--"',

--- a/dask_jobqueue/lsf.py
+++ b/dask_jobqueue/lsf.py
@@ -96,7 +96,6 @@ class LSFJob(Job):
         if walltime is not None:
             header_lines.append("#BSUB -W %s" % walltime)
         header_lines.extend(["#BSUB %s" % arg for arg in job_extra])
-        header_lines.append("JOB_ID=${LSB_JOBID%.*}")
 
         # Declare class attribute that shall be overridden
         self.job_header = "\n".join(header_lines)

--- a/dask_jobqueue/oar.py
+++ b/dask_jobqueue/oar.py
@@ -65,7 +65,6 @@ class OARJob(Job):
         full_resource_spec = ",".join(resource_spec_list)
         header_lines.append("#OAR -l %s" % full_resource_spec)
         header_lines.extend(["#OAR %s" % arg for arg in job_extra])
-        header_lines.append("JOB_ID=${OAR_JOB_ID}")
 
         self.job_header = "\n".join(header_lines)
 

--- a/dask_jobqueue/pbs.py
+++ b/dask_jobqueue/pbs.py
@@ -95,7 +95,6 @@ class PBSJob(Job):
             header_lines.append("#PBS -e %s/" % self.log_directory)
             header_lines.append("#PBS -o %s/" % self.log_directory)
         header_lines.extend(["#PBS %s" % arg for arg in job_extra])
-        header_lines.append("JOB_ID=${PBS_JOBID%%.*}")
 
         # Declare class attribute that shall be overridden
         self.job_header = "\n".join(header_lines)

--- a/dask_jobqueue/slurm.py
+++ b/dask_jobqueue/slurm.py
@@ -76,8 +76,6 @@ class SLURMJob(Job):
             header_lines.append("#SBATCH -t %s" % walltime)
         header_lines.extend(["#SBATCH %s" % arg for arg in job_extra])
 
-        header_lines.append("\nJOB_ID=${SLURM_JOB_ID%;*}")
-
         # Declare class attribute that shall be overridden
         self.job_header = "\n".join(header_lines)
 

--- a/dask_jobqueue/tests/test_htcondor.py
+++ b/dask_jobqueue/tests/test_htcondor.py
@@ -37,7 +37,6 @@ def test_job_script():
         assert 'MY.JobId = "$(ClusterId).$(ProcId)"' in job_script
         assert "LANG=en_US.utf8" in job_script
         assert "LC_ALL=en_US.utf8" in job_script
-        assert "JOB_ID=$F(MY.JobId)" in job_script
         assert "export" not in job_script
         assert "+Extra = True" in job_script
 


### PR DESCRIPTION
`JOB_ID` was added in https://github.com/dask/dask-jobqueue/pull/63. The idea behind it was that the Dask worker name would contain `JOB_ID` so that a scheduler plugin could link Dask workers to a JOB_ID.


