### PR TITLE
JobQueueCluster: pass security along

### DIFF
--- a/dask_jobqueue/core.py
+++ b/dask_jobqueue/core.py
@@ -514,6 +514,7 @@ class JobQueueCluster(SpecCluster):
             loop=loop,
             silence_logs=silence_logs,
             asynchronous=asynchronous,
+            security=security,
             name=name,
         )
 


### PR DESCRIPTION
`JobQueueCluster.__init__` needs to pass the `security` argument to it's super's (`SpecCluster`) `__init__` since it is needed there too.