### PR TITLE
CI: fix URL for miniconda download.

### DIFF
--- a/ci/conda_setup.sh
+++ b/ci/conda_setup.sh
@@ -4,7 +4,7 @@ set -e
 set -x
 
 # Install miniconda
-wget http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda.sh
+wget http://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda.sh
 bash ~/miniconda.sh -b -p $HOME/miniconda
 export PATH="$HOME/miniconda/bin:$PATH"
 conda update conda --yes

--- a/ci/pbs/Dockerfile
+++ b/ci/pbs/Dockerfile
@@ -26,7 +26,7 @@ COPY --from=builder /root/rpmbuild/RPMS/x86_64/pbspro-server-*.rpm .
 # install pbspro and useful packages
 RUN yum install -y pbspro-server-*.rpm curl bzip2 git gcc sudo openssh-server && yum clean all
 # install python
-RUN curl -o miniconda.sh https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh && \
+RUN curl -o miniconda.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh && \
     bash miniconda.sh -f -b -p /opt/anaconda && \
     /opt/anaconda/bin/conda clean -tipy && \
     rm -f miniconda.sh

--- a/ci/sge/Dockerfile-master
+++ b/ci/sge/Dockerfile-master
@@ -4,7 +4,7 @@ ENV LANG C.UTF-8
 
 RUN apt-get update && apt-get install curl bzip2 git gcc -y --fix-missing
 
-RUN curl -o miniconda.sh https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh && \
+RUN curl -o miniconda.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh && \
     bash miniconda.sh -f -b -p /opt/anaconda && \
     /opt/anaconda/bin/conda clean -tipy && \
     rm -f miniconda.sh

--- a/ci/sge/Dockerfile-slave
+++ b/ci/sge/Dockerfile-slave
@@ -4,7 +4,7 @@ ENV LANG C.UTF-8
 
 RUN apt-get update && apt-get install curl bzip2 git gcc -y --fix-missing
 
-RUN curl -o miniconda.sh https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh && \
+RUN curl -o miniconda.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh && \
     bash miniconda.sh -f -b -p /opt/anaconda && \
     /opt/anaconda/bin/conda clean -tipy && \
     rm -f miniconda.sh

--- a/ci/slurm/Dockerfile
+++ b/ci/slurm/Dockerfile
@@ -2,7 +2,7 @@ FROM giovtorres/slurm-docker-cluster
 
 RUN yum install -y iproute
 
-RUN curl -o miniconda.sh https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh && \
+RUN curl -o miniconda.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh && \
     bash miniconda.sh -f -b -p /opt/anaconda && \
     /opt/anaconda/bin/conda clean -tipy && \
     rm -f miniconda.sh


### PR DESCRIPTION
The CI was failing for a few days e.g. https://travis-ci.org/github/dask/dask-jobqueue/jobs/674255373

```
Step 3/7 : RUN curl -o miniconda.sh https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh &&     bash miniconda.sh -f -b -p /opt/anaconda &&     /opt/anaconda/bin/conda clean -tipy &&     rm -f miniconda.sh

 ---> Running in 38114f6ffd06

  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current

                                 Dload  Upload   Total   Spent    Left  Speed

  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0

bash: miniconda.sh: No such file or directory
```
This returns an empty file or even on CentOS does not even create the file:
```
curl -o miniconda.sh https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
```
