### PR TITLE
Add minimal htcondor CI support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,9 @@ matrix:
     - python: "3.6"
       env:
         - JOBQUEUE=slurm
+    - python: "3.6"
+      env:
+        - JOBQUEUE=htcondor
 
 before_install:
   - set -e

--- a/ci/htcondor.sh
+++ b/ci/htcondor.sh
@@ -17,11 +17,12 @@ function jobqueue_install {
     docker cp . jobqueue-htcondor-mini:/dask-jobqueue 
 
     docker exec --user root jobqueue-htcondor-mini /bin/bash -c "
-    	yum -y install python3-psutil; # psutil has no wheel , install gcc even slower
+    	python3 -c 'import psutil' 2>/dev/null || yum -y install python3-psutil; # psutil has no wheel , install gcc even slower
 	cd /dask-jobqueue; 
 	pip3 install -e .;
 	pip3 install pytest;
 	rm -f /var/log/condor/*
+	chown -R submituser:submituser /dask-jobqueue 
     "
 }
 [[ "${BASH_SOURCE[0]}" != "${0}" ]] || jobqueue_install # excute if called as script

--- a/ci/htcondor.sh
+++ b/ci/htcondor.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+function jobqueue_before_install {
+    docker version
+
+    docker run -d --name jobqueue-htcondor-mini htcondor/mini:el7 # might fail if called as script
+
+    docker ps -a
+    docker images
+}
+[[ "${BASH_SOURCE[0]}" != "${0}" ]] || jobqueue_before_install # excute if called as script
+
+function jobqueue_install {
+    docker exec --user root jobqueue-htcondor-mini  /bin/bash -c "
+    	rm -rf /dask-jobqueue
+   "
+    docker cp . jobqueue-htcondor-mini:/dask-jobqueue 
+
+    docker exec --user root jobqueue-htcondor-mini /bin/bash -c "
+    	yum -y install python3-psutil; # psutil has no wheel , install gcc even slower
+	cd /dask-jobqueue; 
+	pip3 install -e .;
+	pip3 install pytest;
+	rm -f /var/log/condor/*
+    "
+}
+[[ "${BASH_SOURCE[0]}" != "${0}" ]] || jobqueue_install # excute if called as script
+
+function jobqueue_script {
+    docker exec --user=submituser jobqueue-htcondor-mini /bin/bash -c "
+    	cd /dask-jobqueue; 
+	pytest dask_jobqueue --verbose -s -E htcondor"
+}
+[[ "${BASH_SOURCE[0]}" != "${0}" ]] || jobqueue_script # excute if called as script
+
+function jobqueue_after_script {
+    docker exec --user root jobqueue-htcondor-mini /bin/bash -c "
+    	grep -R \"\" /var/log/condor/	
+   "
+}
+[[ "${BASH_SOURCE[0]}" != "${0}" ]] || jobqueue_after_script # excute if called as script

--- a/dask_jobqueue/tests/test_htcondor.py
+++ b/dask_jobqueue/tests/test_htcondor.py
@@ -57,9 +57,7 @@ def test_basic(loop):
             cluster.scale(2)
 
             start = time()
-            while not (cluster.pending_jobs or cluster.running_jobs):
-                sleep(0.100)
-                assert time() < start + QUEUE_WAIT
+            client.wait_for_workers(2)
 
             future = client.submit(lambda x: x + 1, 10)
             assert future.result(QUEUE_WAIT) == 11

--- a/dask_jobqueue/tests/test_htcondor.py
+++ b/dask_jobqueue/tests/test_htcondor.py
@@ -61,7 +61,6 @@ def test_basic(loop):
 
             future = client.submit(lambda x: x + 1, 10)
             assert future.result(QUEUE_WAIT) == 11
-            assert cluster.running_jobs
 
             workers = list(client.scheduler_info()["workers"].values())
             w = workers[0]
@@ -71,7 +70,7 @@ def test_basic(loop):
             cluster.scale(0)
 
             start = time()
-            while cluster.running_jobs:
+            while client.scheduler_info()["workers"]:
                 sleep(0.100)
                 assert time() < start + QUEUE_WAIT
 


### PR DESCRIPTION
I set up a really minimal ci/htcondor.sh to address #247. No other files needed sofar.

A test fails, but this seems to be actually a real issue: 
> 'HTCondorCluster' object has no attribute 'pending_jobs'

Please give it a try!

I thought I'd rather do sth if you add me to the team ;) 