### PR TITLE
Improve consistency of SGE cluster object with other clusters

### DIFF
--- a/dask_jobqueue/sge.py
+++ b/dask_jobqueue/sge.py
@@ -120,3 +120,4 @@ class SGECluster(JobQueueCluster):
         job=job_parameters, cluster=cluster_parameters
     )
     job_cls = SGEJob
+    config_name = "sge"


### PR DESCRIPTION
I tried to access `*Cluster.config_name` for all available clusters during a test scenario currently developed [here](https://github.com/dask/dask-jobqueue/pull/405#discussion_r418159072). This was possible for all clusters, except SGE. To have the cluster objects consistent the attribute should be added, I think.