### PR TITLE
WIP do not merge: Fix slurm CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,6 @@ notifications:
 services:
   - docker
 
-addons:
-  apt:
-    packages:
-      - docker-ce
-
 matrix:
   include:
 #     - python: "3.6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,12 @@ notifications:
 
 services:
   - docker
+
+addons:
+  apt:
+    packages:
+      - docker-ce
+
 matrix:
   include:
 #     - python: "3.6"
@@ -25,6 +31,7 @@ matrix:
 before_install:
   - set -e
   - pwd
+  - pip install docker-compose
   # Init jobqueue environment: load init and test methods
   - source ci/${JOBQUEUE}.sh
   - jobqueue_before_install

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,10 @@ matrix:
 before_install:
   - set -e
   - pwd
+  - curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+  - sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+  - sudo apt-get update
+  - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
   - pip install docker-compose
   # Init jobqueue environment: load init and test methods
   - source ci/${JOBQUEUE}.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,16 +8,16 @@ services:
   - docker
 matrix:
   include:
-    - python: "3.6"
-      env:
-        - JOBQUEUE=sge
-    - python: "3.6"
-      env:
-        # JOBQUEUE=none is for tests that do not need a cluster to run
-        - JOBQUEUE=none
-    - python: "3.6"
-      env:
-        - JOBQUEUE=pbs
+#     - python: "3.6"
+#       env:
+#         - JOBQUEUE=sge
+#     - python: "3.6"
+#       env:
+#         # JOBQUEUE=none is for tests that do not need a cluster to run
+#         - JOBQUEUE=none
+#     - python: "3.6"
+#       env:
+#         - JOBQUEUE=pbs
     - python: "3.6"
       env:
         - JOBQUEUE=slurm

--- a/ci/slurm/docker-compose.yml
+++ b/ci/slurm/docker-compose.yml
@@ -49,7 +49,7 @@ services:
       - "slurmdbd"
     networks:
       common-network:
-        ipv4_address: 10.1.1.10
+        ipv4_address: 10.23.24.10
     cap_add:
       - NET_ADMIN
 
@@ -69,7 +69,7 @@ services:
       - "slurmctld"
     networks:
       common-network:
-        ipv4_address: 10.1.1.11
+        ipv4_address: 10.23.24.11
     cap_add:
       - NET_ADMIN
 
@@ -89,7 +89,7 @@ services:
       - "slurmctld"
     networks:
       common-network:
-        ipv4_address: 10.1.1.12
+        ipv4_address: 10.23.24.12
     cap_add:
       - NET_ADMIN
 
@@ -106,4 +106,4 @@ networks:
     ipam:
       driver: default
       config:
-        - subnet: 10.1.1.0/24
+        - subnet: 10.23.24.0/24

--- a/ci/slurm/docker-compose.yml
+++ b/ci/slurm/docker-compose.yml
@@ -24,6 +24,7 @@ services:
       - etc_munge:/etc/munge
       - etc_slurm:/etc/slurm
       - var_log_slurm:/var/log/slurm
+    restart: on-failure
     expose:
       - "6819"
     depends_on:

--- a/ci/slurm/start-slurm.sh
+++ b/ci/slurm/start-slurm.sh
@@ -2,10 +2,14 @@
 
 docker-compose up --build -d
 
-while [ `./register_cluster.sh 2>&1 | grep "sacctmgr: error" | wc -l` -ne 0 ]
+bla=$(`./register_cluster.sh 2>&1)
+while [ `echo $bla | grep "sacctmgr: error" | wc -l` -ne 0 ]
   do
+    echo Cluster is not ready
+    echo "$bla"
     echo "Waiting for SLURM cluster to become ready";
     sleep 2
+    bla=$(`./register_cluster.sh 2>&1)
   done
 echo "SLURM properly configured"
 

--- a/ci/slurm/start-slurm.sh
+++ b/ci/slurm/start-slurm.sh
@@ -8,7 +8,7 @@ while [ `echo $bla | grep "sacctmgr: error" | wc -l` -ne 0 ]
     echo Cluster is not ready
     echo "$bla"
     docker-compose ps
-    docker-compose ps | grep slurmdbd && docker-compose start slurmdbd || echo slurmdbd alive
+    # docker-compose ps | grep slurmdbd && docker-compose start slurmdbd || echo slurmdbd alive
     echo "Waiting for SLURM cluster to become ready";
     sleep 2
     bla=$(./register_cluster.sh 2>&1)

--- a/ci/slurm/start-slurm.sh
+++ b/ci/slurm/start-slurm.sh
@@ -2,7 +2,7 @@
 
 docker-compose up --build -d
 
-bla=$(`./register_cluster.sh 2>&1)
+bla=$(./register_cluster.sh 2>&1)
 while [ `echo $bla | grep "sacctmgr: error" | wc -l` -ne 0 ]
   do
     echo Cluster is not ready

--- a/ci/slurm/start-slurm.sh
+++ b/ci/slurm/start-slurm.sh
@@ -2,7 +2,7 @@
 
 docker-compose up --build -d
 
-sleep 60
+sleep 30
 
 bla=$(./register_cluster.sh 2>&1)
 while [ `echo $bla | grep "sacctmgr: error" | wc -l` -ne 0 ]
@@ -10,9 +10,9 @@ while [ `echo $bla | grep "sacctmgr: error" | wc -l` -ne 0 ]
     echo Cluster is not ready
     echo "$bla"
     echo "Waiting for SLURM cluster to become ready";
-    sleep 20
+    sleep 30
     docker-compose ps
-    docker-compose logs --timestamps --tail=30 slurmdbd mysql slurmctld
+    docker-compose logs --timestamps slurmdbd mysql slurmctld
     bla=$(./register_cluster.sh 2>&1)
   done
 echo "SLURM properly configured"

--- a/ci/slurm/start-slurm.sh
+++ b/ci/slurm/start-slurm.sh
@@ -8,9 +8,9 @@ while [ `echo $bla | grep "sacctmgr: error" | wc -l` -ne 0 ]
     echo Cluster is not ready
     echo "$bla"
     echo "Waiting for SLURM cluster to become ready";
-    sleep 10
+    sleep 20
     docker-compose ps
-    docker-compose logs --tail=30 slurmdbd mysql slurmctld
+    docker-compose logs --timestamps --tail=30 slurmdbd mysql slurmctld
     bla=$(./register_cluster.sh 2>&1)
   done
 echo "SLURM properly configured"

--- a/ci/slurm/start-slurm.sh
+++ b/ci/slurm/start-slurm.sh
@@ -8,6 +8,7 @@ while [ `echo $bla | grep "sacctmgr: error" | wc -l` -ne 0 ]
     echo Cluster is not ready
     echo "$bla"
     docker-compose ps
+    docker-compose ps | grep slurmdbd && docker-compose start slurmdbd || echo slurmdbd alive
     echo "Waiting for SLURM cluster to become ready";
     sleep 2
     bla=$(./register_cluster.sh 2>&1)

--- a/ci/slurm/start-slurm.sh
+++ b/ci/slurm/start-slurm.sh
@@ -9,7 +9,7 @@ while [ `echo $bla | grep "sacctmgr: error" | wc -l` -ne 0 ]
     echo "$bla"
     docker-compose ps
     docker-compose logs
-    # docker-compose ps | grep slurmdbd && docker-compose start slurmdbd || echo slurmdbd alive
+    docker-compose ps | grep -P 'slurmdbd.+Exit' && docker-compose start slurmdbd || echo slurmdbd alive
     echo "Waiting for SLURM cluster to become ready";
     sleep 2
     bla=$(./register_cluster.sh 2>&1)

--- a/ci/slurm/start-slurm.sh
+++ b/ci/slurm/start-slurm.sh
@@ -1,12 +1,13 @@
 #!/bin/bash
 
-docker-compose up --build
+docker-compose up --build -d
 
 bla=$(./register_cluster.sh 2>&1)
 while [ `echo $bla | grep "sacctmgr: error" | wc -l` -ne 0 ]
   do
     echo Cluster is not ready
     echo "$bla"
+    docker-compose ps
     echo "Waiting for SLURM cluster to become ready";
     sleep 2
     bla=$(./register_cluster.sh 2>&1)

--- a/ci/slurm/start-slurm.sh
+++ b/ci/slurm/start-slurm.sh
@@ -2,6 +2,8 @@
 
 docker-compose up --build -d
 
+sleep 60
+
 bla=$(./register_cluster.sh 2>&1)
 while [ `echo $bla | grep "sacctmgr: error" | wc -l` -ne 0 ]
   do

--- a/ci/slurm/start-slurm.sh
+++ b/ci/slurm/start-slurm.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-docker-compose up --build -d
+docker-compose up --build
 
 bla=$(./register_cluster.sh 2>&1)
 while [ `echo $bla | grep "sacctmgr: error" | wc -l` -ne 0 ]

--- a/ci/slurm/start-slurm.sh
+++ b/ci/slurm/start-slurm.sh
@@ -8,8 +8,8 @@ while [ `echo $bla | grep "sacctmgr: error" | wc -l` -ne 0 ]
     echo Cluster is not ready
     echo "$bla"
     docker-compose ps
-    docker-compose logs
-    docker-compose ps | grep -P 'slurmdbd.+Exit' && docker-compose start slurmdbd || echo slurmdbd alive
+    # docker-compose logs
+    # docker-compose ps | grep -P 'slurmdbd.+Exit' && docker-compose start slurmdbd || echo slurmdbd alive
     echo "Waiting for SLURM cluster to become ready";
     sleep 2
     bla=$(./register_cluster.sh 2>&1)

--- a/ci/slurm/start-slurm.sh
+++ b/ci/slurm/start-slurm.sh
@@ -9,7 +9,7 @@ while [ `echo $bla | grep "sacctmgr: error" | wc -l` -ne 0 ]
     echo "$bla"
     echo "Waiting for SLURM cluster to become ready";
     sleep 2
-    bla=$(`./register_cluster.sh 2>&1)
+    bla=$(./register_cluster.sh 2>&1)
   done
 echo "SLURM properly configured"
 

--- a/ci/slurm/start-slurm.sh
+++ b/ci/slurm/start-slurm.sh
@@ -8,6 +8,7 @@ while [ `echo $bla | grep "sacctmgr: error" | wc -l` -ne 0 ]
     echo Cluster is not ready
     echo "$bla"
     docker-compose ps
+    docker-compose logs
     # docker-compose ps | grep slurmdbd && docker-compose start slurmdbd || echo slurmdbd alive
     echo "Waiting for SLURM cluster to become ready";
     sleep 2

--- a/ci/slurm/start-slurm.sh
+++ b/ci/slurm/start-slurm.sh
@@ -7,11 +7,10 @@ while [ `echo $bla | grep "sacctmgr: error" | wc -l` -ne 0 ]
   do
     echo Cluster is not ready
     echo "$bla"
-    docker-compose ps
-    # docker-compose logs
-    # docker-compose ps | grep -P 'slurmdbd.+Exit' && docker-compose start slurmdbd || echo slurmdbd alive
     echo "Waiting for SLURM cluster to become ready";
-    sleep 2
+    sleep 10
+    docker-compose ps
+    docker-compose logs --tail=30 slurmdbd mysql slurmctld
     bla=$(./register_cluster.sh 2>&1)
   done
 echo "SLURM properly configured"


### PR DESCRIPTION
So our Slurm CI has started failing April 28.
- no change from our side
- no change from giovtorres/slurm-docker-cluster
- unable to reproduce the problem locally

What I have tried so far to no avail:
- use the latest docker and docker-compose
- try tweaking sleep times hoping that the problem will go away
- use `restart: always` for `slurmdbd` because it was killed for some reason (Exited 139 IIRC)
- remove the `network` stuff from `docker-compose.yml` to see whether it was the culprit (no it is not)

The error from `register_cluster.sh` is something like:
```
sacctmgr: error: slurm_persist_conn_open_without_init: failed to open persistent connection to slurmdbd:6819: Connection refused
sacctmgr: error: slurmdbd: Getting response to message type: DBD_ADD_CLUSTERS

 Problem adding clusters: Unspecified error
sacctmgr: error: slurmdbd: Sending PersistInit msg: Connection refused
```

The things I noticed from the docker logs (`mysql` container):
```
2020-05-01T16:45:54.757910090Z 2020-05-01T16:45:54.757725Z 5 [Note] Aborted connection 5 to db: 'slurm_acct_db' user: 'slurm' host: '10.23.24.3' (Got an error reading communication packets)
```

Is it the root cause of the problem, who knows?

Maybe if someone has a suggestion from @dask/slurm @guillaumeeb I am interested ...