### PR TITLE
Fix mysql version to get Slurm CI green

### DIFF
--- a/ci/slurm/docker-compose.yml
+++ b/ci/slurm/docker-compose.yml
@@ -2,7 +2,7 @@ version: "2.2"
 
 services:
   mysql:
-    image: mysql:5.7
+    image: mysql:5.7.29
     hostname: mysql
     container_name: mysql
     environment:


### PR DESCRIPTION
I just checked what happened when suddenly the slurm CI stopped working. The only relevant thing I saw was a version bump in the mysql docker image.

I'll close this PR immediately if Travis does not work...