### PR TITLE
CLN remove config_name from cluster classes.

### DIFF
--- a/dask_jobqueue/htcondor.py
+++ b/dask_jobqueue/htcondor.py
@@ -236,4 +236,3 @@ class HTCondorCluster(JobQueueCluster):
         job=job_parameters, cluster=cluster_parameters
     )
     job_cls = HTCondorJob
-    config_name = "htcondor"

--- a/dask_jobqueue/local.py
+++ b/dask_jobqueue/local.py
@@ -104,4 +104,3 @@ class LocalCluster(JobQueueCluster):
         job=job_parameters, cluster=cluster_parameters
     )
     job_cls = LocalJob
-    config_name = "local"

--- a/dask_jobqueue/lsf.py
+++ b/dask_jobqueue/lsf.py
@@ -232,7 +232,6 @@ class LSFCluster(JobQueueCluster):
         job=job_parameters, cluster=cluster_parameters
     )
     job_cls = LSFJob
-    config_name = "lsf"
 
 
 @toolz.memoize

--- a/dask_jobqueue/oar.py
+++ b/dask_jobqueue/oar.py
@@ -131,4 +131,3 @@ class OARCluster(JobQueueCluster):
         job=job_parameters, cluster=cluster_parameters
     )
     job_cls = OARJob
-    config_name = "oar"

--- a/dask_jobqueue/pbs.py
+++ b/dask_jobqueue/pbs.py
@@ -140,4 +140,3 @@ class PBSCluster(JobQueueCluster):
         job=job_parameters, cluster=cluster_parameters
     )
     job_cls = PBSJob
-    config_name = "pbs"

--- a/dask_jobqueue/slurm.py
+++ b/dask_jobqueue/slurm.py
@@ -150,4 +150,3 @@ class SLURMCluster(JobQueueCluster):
         job=job_parameters, cluster=cluster_parameters
     )
     job_cls = SLURMJob
-    config_name = "slurm"


### PR DESCRIPTION
This should have been done in #366. `config_name` now lives in the job class. To access the default config name from a cluster class you can do: `self.job_cls.default_config_name()`