### PR TITLE
Tweak name in cluster.job_script().

### DIFF
--- a/dask_jobqueue/core.py
+++ b/dask_jobqueue/core.py
@@ -555,7 +555,12 @@ class JobQueueCluster(SpecCluster):
         try:
             return self.job_cls(
                 address or "tcp://<insert-scheduler-address-here>:8786",
-                name="name",
+                # The 'name' parameter is replaced inside Job class by the
+                # actual Dask worker name. Using 'dummy-name here' to make it
+                # more clear that cluster.job_script() is similar to but not
+                # exactly the same script as the script submitted for each Dask
+                # worker
+                name="dummy-name",
                 **self._job_kwargs
             )
         except TypeError as exc:


### PR DESCRIPTION
I was quite surprised by this in https://github.com/dask/dask-jobqueue/issues/196#issuecomment-630292957 at one point and forgot that `cluster.job_script()` is not exactly the same script that is submitted for each submission script that runs `dask-worker`.

Also dummy-name is easier to grep than name, so easier to reach the comment as well next time I forget about this and need to be remembered.