### PR TITLE
Fix math typo in GiB definition

### DIFF
--- a/docs/source/configuration-setup.rst
+++ b/docs/source/configuration-setup.rst
@@ -53,7 +53,7 @@ Gigabyte vs Gibibyte
 It is important to note that Dask makes the difference between 
 power of 2 and power of 10 when specifying memory. This means that:
 - 1GB = :math:`10^9` bytes
-- 1GiB = :math:`2^30` bytes
+- 1GiB = :math:`2^{30}` bytes
 
 ``memory`` configuration is interpreted by Dask memory parser, and for most
 JobQueueCluster implementation translated as a resource requirement for job 


### PR DESCRIPTION
While reading the documentation at https://jobqueue.dask.org/en/latest/configuration-setup.html
I noticed a strange "1 GiB = 2³0 bytes" and realized it should be "1 GiB = 2³⁰ bytes"
This fixes that typo.