### PR TITLE
Include Github release in release procedure

### DIFF
--- a/docs/release-procedure.md
+++ b/docs/release-procedure.md
@@ -21,6 +21,9 @@ git tag -a x.x.x -m 'Version x.x.x'
 git push --tags upstream
 ````
 
+* Create a [new Github release](https://github.com/dask/dask-jobqueue/releases/new)
+based on the tag that has just been pushed.
+
 * Build the wheel/dist and upload to PyPI:
 
 ````


### PR DESCRIPTION
Closes #446

As Github distinguishes releases and tags, we need to explicitly create a release from a tagged version.