### PR TITLE
Give MoabCluster a unique config_name

### DIFF
--- a/dask_jobqueue/moab.py
+++ b/dask_jobqueue/moab.py
@@ -10,3 +10,4 @@ class MoabJob(PBSJob):
 class MoabCluster(PBSCluster):
     __doc__ = PBSCluster.__doc__.replace("PBSCluster", "MoabCluster")
     job_cls = MoabJob
+    config_name = "moab"

--- a/dask_jobqueue/moab.py
+++ b/dask_jobqueue/moab.py
@@ -4,10 +4,9 @@ from .pbs import PBSJob, PBSCluster
 class MoabJob(PBSJob):
     submit_command = "msub"
     cancel_command = "canceljob"
-    scheduler_name = "moab"
+    config_name = "moab"
 
 
 class MoabCluster(PBSCluster):
     __doc__ = PBSCluster.__doc__.replace("PBSCluster", "MoabCluster")
     job_cls = MoabJob
-    config_name = "moab"

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -7,7 +7,7 @@ Development version
 - all cluster classes: fix a bug that would allow to pass any named parameter without an error (:pr:`398`)
 - all cluster classes: fix a bug where ``security`` was not correctly passed through (:pr:`398`)
 - ``MoabCluster``: fix bug where ``MoabCluster`` was using the ``jobqueue.pbs``
-  config section rather than the ``jobqueue.moab`` section.
+  config section rather than the ``jobqueue.moab`` section. (:pr:`450`)
 
 0.7.1 / 2020-03-26
 ------------------

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -6,7 +6,8 @@ Development version
 
 - all cluster classes: fix a bug that would allow to pass any named parameter without an error (:pr:`398`)
 - all cluster classes: fix a bug where ``security`` was not correctly passed through (:pr:`398`)
-
+- ``MoabCluster``: fix bug where ``MoabCluster`` was using the ``jobqueue.pbs``
+  config section rather than the ``jobqueue.moab`` section.
 
 0.7.1 / 2020-03-26
 ------------------


### PR DESCRIPTION
Allow moab and pbs clusters to have separate yaml config sections.