### PR TITLE
Updating start_workers to scale in examples

### DIFF
--- a/dask_jobqueue/tests/test_lsf.py
+++ b/dask_jobqueue/tests/test_lsf.py
@@ -121,7 +121,7 @@ def test_basic(loop):
         loop=loop,
     ) as cluster:
         with Client(cluster) as client:
-            cluster.start_workers(2)
+            cluster.scale(2)
             assert cluster.pending_jobs or cluster.running_jobs
             future = client.submit(lambda x: x + 1, 10)
             assert future.result(QUEUE_WAIT) == 11

--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -158,7 +158,6 @@ to the dask-workers.
                            cores=2,
                            extra=['--resources ssdGB=200,GPU=2'])
 
-    # previous versions used cluster.start_workers(2)
     cluster.scale(2)
     client = Client(cluster)
 

--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -158,7 +158,8 @@ to the dask-workers.
                            cores=2,
                            extra=['--resources ssdGB=200,GPU=2'])
 
-    cluster.start_workers(2)
+    # previous versions used cluster.start_workers(2)
+    cluster.scale(2)
     client = Client(cluster)
 
 The client can then be used as normal. Additionally, required resources can be


### PR DESCRIPTION
The dask-jobqueue library, for the slurm executor, has been updated to use `scale` instead of `start_workers` and it looks like the docs don't reflect that yet.