### PR TITLE
Add GH action to periodically build docker images

### DIFF
--- a/.github/workflows/build-docker-images.yaml
+++ b/.github/workflows/build-docker-images.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        jobqueue: ["htcondor", "pbs", "sge", "slurm", "none"]
+        jobqueue: ["pbs", "sge", "slurm"]
 
     steps:
       - name: Checkout

--- a/.github/workflows/build-docker-images.yaml
+++ b/.github/workflows/build-docker-images.yaml
@@ -1,6 +1,8 @@
 name: docker-images-build
 
 on:
+  push:
+    branches: "master"
   schedule:
     - cron: "0 0 * * *" # Daily “At 00:00”
 

--- a/.github/workflows/build-docker-images.yaml
+++ b/.github/workflows/build-docker-images.yaml
@@ -2,7 +2,7 @@ name: docker-images-build
 
 on:
   schedule:
-    - cron: "0 0 * * 0" # Weekly “At 00:00 on Sunday.”
+    - cron: "0 0 * * *" # Daily “At 00:00”
 
 jobs:
   build:

--- a/.github/workflows/build-docker-images.yaml
+++ b/.github/workflows/build-docker-images.yaml
@@ -1,10 +1,8 @@
 name: docker-images-build
 
 on:
-  push:
-    branches: "*"
   schedule:
-    - cron: "0 0 * * *"
+    - cron: "0 0 * * 0" # Weekly “At 00:00 on Sunday.”
  
 
 jobs:

--- a/.github/workflows/build-docker-images.yaml
+++ b/.github/workflows/build-docker-images.yaml
@@ -3,7 +3,6 @@ name: docker-images-build
 on:
   schedule:
     - cron: "0 0 * * 0" # Weekly “At 00:00 on Sunday.”
- 
 
 jobs:
   build:
@@ -20,16 +19,16 @@ jobs:
         run: |
           docker version
           docker-compose version
-      - name:  Building Image 
+      - name: Building Image
         shell: bash -l {0}
         run: |
           cd ./ci/${{ matrix.jobqueue }}
-          docker-compose build 
+          docker-compose build
       - name: List images
         run: |
           docker ps -a 
           docker images
-          
+
       - name: Publish main images to DockerHub Registry
         if: github.ref == 'refs/heads/master' && github.event_name == 'push'
         uses: elgohr/Publish-Docker-Github-Action@master
@@ -45,7 +44,3 @@ jobs:
           name: daskdev/dask-jobqueue:${{ matrix.jobqueue }}-slave
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-
-
-          
-      

--- a/.github/workflows/build-docker-images.yaml
+++ b/.github/workflows/build-docker-images.yaml
@@ -25,7 +25,7 @@ jobs:
       - name:  Building Image 
         shell: bash -l {0}
         run: |
-          cd ./ci/{{ matrix.jobqueue }}
+          cd ./ci/${{ matrix.jobqueue }}
           docker-compose build 
       - name: List images
         run: |

--- a/.github/workflows/build-docker-images.yaml
+++ b/.github/workflows/build-docker-images.yaml
@@ -34,16 +34,14 @@ jobs:
 
       - name: Publish main images to DockerHub Registry
         if: github.ref == 'refs/heads/master' && github.event_name == 'push'
-        uses: elgohr/Publish-Docker-Github-Action@master
-        with:
-          name: daskdev/dask-jobqueue:${{ matrix.jobqueue }}
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+        run: | 
+          echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
+          docker push daskdev/dask-jobqueue:${{ matrix.jobqueue }}
+
 
       - name: Publish secondary images to DockerHub Registry
         if: matrix.jobqueue == 'sge' && github.ref == 'refs/heads/master' && github.event_name == 'push'
-        uses: elgohr/Publish-Docker-Github-Action@master
-        with:
-          name: daskdev/dask-jobqueue:${{ matrix.jobqueue }}-slave
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+        run: | 
+          echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
+          docker push daskdev/dask-jobqueue:${{ matrix.jobqueue }}-slave
+       

--- a/.github/workflows/build-docker-images.yaml
+++ b/.github/workflows/build-docker-images.yaml
@@ -1,0 +1,37 @@
+name: dask-jobqueue-docker-images-build
+
+on:
+  push:
+    branches: "*"
+  schedule:
+    - cron: "0 0 * * *"
+ 
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        jobqueue: ["htcondor", "pbs", "sge", "slurm", "none"]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup tmate session # for debugging GH action by using tmate
+        uses: mxschmitt/action-tmate@v2
+      - name: Check versions
+        run: |
+          docker version
+          docker-compose version
+      - name:  Building Image 
+        shell: bash -l {0}
+        run: |
+          cd ./ci/{{ matrix.jobqueue }}
+          docker-compose build 
+      - name: List images
+        run: |
+          docker ps -a 
+          docker images
+          
+      

--- a/.github/workflows/build-docker-images.yaml
+++ b/.github/workflows/build-docker-images.yaml
@@ -32,4 +32,12 @@ jobs:
           docker ps -a 
           docker images
           
+      - name: Publish to DockerHub Registry
+        if: github.ref == 'refs/heads/master' && github.event_name == 'push'
+        uses: elgohr/Publish-Docker-Github-Action@master
+        with:
+          name: daskdev/dask-jobqueue:${{ matrix.jobqueue }}
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          
       

--- a/.github/workflows/build-docker-images.yaml
+++ b/.github/workflows/build-docker-images.yaml
@@ -18,8 +18,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Setup tmate session # for debugging GH action by using tmate
-        uses: mxschmitt/action-tmate@v2
       - name: Check versions
         run: |
           docker version

--- a/.github/workflows/build-docker-images.yaml
+++ b/.github/workflows/build-docker-images.yaml
@@ -1,4 +1,4 @@
-name: dask-jobqueue-docker-images-build
+name: docker-images-build
 
 on:
   push:
@@ -32,12 +32,22 @@ jobs:
           docker ps -a 
           docker images
           
-      - name: Publish to DockerHub Registry
+      - name: Publish main images to DockerHub Registry
         if: github.ref == 'refs/heads/master' && github.event_name == 'push'
         uses: elgohr/Publish-Docker-Github-Action@master
         with:
           name: daskdev/dask-jobqueue:${{ matrix.jobqueue }}
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Publish secondary images to DockerHub Registry
+        if: github.ref == 'refs/heads/master' && github.event_name == 'push' && ${{ matrix.jobqueue }} == 'sge'
+        uses: elgohr/Publish-Docker-Github-Action@master
+        with:
+          name: daskdev/dask-jobqueue:${{ matrix.jobqueue }}-slave
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+
           
       

--- a/.github/workflows/build-docker-images.yaml
+++ b/.github/workflows/build-docker-images.yaml
@@ -5,6 +5,7 @@ on:
     branches: "master"
   schedule:
     - cron: "0 0 * * *" # Daily “At 00:00”
+  workflow_dispatch: # allows you to trigger manually
 
 jobs:
   build:

--- a/.github/workflows/build-docker-images.yaml
+++ b/.github/workflows/build-docker-images.yaml
@@ -41,7 +41,7 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Publish secondary images to DockerHub Registry
-        if: github.ref == 'refs/heads/master' && github.event_name == 'push' && ${{ matrix.jobqueue }} == 'sge'
+        if: matrix.jobqueue == 'sge' && github.ref == 'refs/heads/master' && github.event_name == 'push'
         uses: elgohr/Publish-Docker-Github-Action@master
         with:
           name: daskdev/dask-jobqueue:${{ matrix.jobqueue }}-slave

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 Deploy Dask on Job Queueing systems
 ===================================
 
-|Build Status| |Doc Status| |Gitter| |Version Status|
+|Build Status| |Doc Status| |Gitter| |Version Status| |Docker Images Build Status|
 
 Easy deployment of Dask Distributed on job queuing systems such as PBS, Slurm,
 or SGE.  See documentation_ for more information.

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 Deploy Dask on Job Queueing systems
 ===================================
 
-|Build Status| |Doc Status| |Gitter| |Version Status| |Docker Images Build Status|
+|Build Status| |Doc Status| |Gitter| |Version Status|
 
 Easy deployment of Dask Distributed on job queuing systems such as PBS, Slurm,
 or SGE.  See documentation_ for more information.
@@ -23,5 +23,3 @@ New BSD. See `License File <https://github.com/dask/dask-jobqueue/blob/master/LI
    :target: https://gitter.im/dask/dask?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge
 .. |Version Status| image:: https://img.shields.io/pypi/v/dask-jobqueue.svg
    :target: https://pypi.python.org/pypi/dask-jobqueue/
-.. |Docker Images Build Status| image:: https://img.shields.io/github/workflow/status/dask/dask-jobqueue/docker-images-build?logo=docker   
-   :target: https://github.com/dask/dask-jobqueue/actions?query=workflow%3Adocker-images-build

--- a/README.rst
+++ b/README.rst
@@ -23,3 +23,5 @@ New BSD. See `License File <https://github.com/dask/dask-jobqueue/blob/master/LI
    :target: https://gitter.im/dask/dask?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge
 .. |Version Status| image:: https://img.shields.io/pypi/v/dask-jobqueue.svg
    :target: https://pypi.python.org/pypi/dask-jobqueue/
+.. |Docker Images Build Status| image:: https://img.shields.io/github/workflow/status/dask/dask-jobqueue/docker-images-build?logo=docker   
+   :target: https://github.com/dask/dask-jobqueue/actions?query=workflow%3Adocker-images-build


### PR DESCRIPTION
Fixes #433 and amends https://github.com/dask/dask-jobqueue/pull/432

For this action to work properly, we need to set both the DOCKER_USERNAME, DOCKER_PASSWORD secrets in the repo settings. However, I currently don't have admin rights on this repo. 