### PR TITLE
[doc] Fix link format inside an italicised text

### DIFF
--- a/docs/source/interactive.rst
+++ b/docs/source/interactive.rst
@@ -9,7 +9,7 @@ We recommend first doing these steps from a login node (nothing will be
 computationally intensive) but at some point you may want to shift to a compute
 or interactive node.
 
-*Note: We also recommend the `JupyterHub <https://jupyter.org/hub>`_ project,
+*Note: We also recommend the* `JupyterHub <https://jupyter.org/hub>`_ *project,
 which allows HPC administrators to offer and control the process described
 in this document automatically.  If you find this process valuable but tedious,
 then you may want to ask your system administrators to support it with


### PR DESCRIPTION
RST doesn't allow nested formatting and therefore [the link doesn't appear properly in the documentation](https://jobqueue.dask.org/en/latest/interactive.html). There are various ways to solve this so that also *JupyterHub* appears in italics. However, I found this being the simplest.

An alternative would be to use the [`.. note::`](https://sublime-and-sphinx-guide.readthedocs.io/en/latest/notes_warnings.html) directive instead, which may be easier to maintain.