### PR TITLE
Skip building docker images when the image is present

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 30
     defaults:
       run:
         shell: bash -l {0}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,6 +5,9 @@ on: [push, pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash -l {0}
     strategy:
       fail-fast: false
       matrix:
@@ -17,32 +20,32 @@ jobs:
       - name: Setup Conda Environment
         uses: goanpeca/setup-miniconda@v1
         with:
-          miniconda-version: "latest"
-          python-version: 3.6
-          environment-file: ci/environment.yml
+          channels: conda-forge
+          mamba-version: "*"
           activate-environment: dask-jobqueue
           auto-activate-base: false
+         
+      - name: Setup conda environment 
+        run: |
+          mamba env update -f ci/environment.yml
+          mamba list
 
       - name: Setup
-        shell: bash -l {0}
         run: |
           source ci/${{ matrix.jobqueue }}.sh
           jobqueue_before_install
 
       - name: Install
-        shell: bash -l {0}
         run: |
           source ci/${{ matrix.jobqueue }}.sh
           jobqueue_install
 
       - name: Test
-        shell: bash -l {0}
         run: |
           source ci/${{ matrix.jobqueue }}.sh
           jobqueue_script
 
       - name: Cleanup
-        shell: bash -l {0}
         run: |
           source ci/${{ matrix.jobqueue }}.sh
           jobqueue_after_script

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,6 +15,10 @@ jobs:
         jobqueue: ["htcondor", "pbs", "sge", "slurm", "none"]
 
     steps:
+      - name: Cancel previous runs
+        uses: styfle/cancel-workflow-action@0.7.0
+        with:
+            access_token: ${{ github.token }}
       - name: Checkout source
         uses: actions/checkout@v2
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Checkout source
         uses: actions/checkout@v2
 
-      - name: Setup Conda Environment
+      - name: Setup miniconda
         uses: goanpeca/setup-miniconda@v1
         with:
           channels: conda-forge

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,6 +5,7 @@ on: [push, pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     defaults:
       run:
         shell: bash -l {0}

--- a/ci/pbs/start-pbs.sh
+++ b/ci/pbs/start-pbs.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-docker-compose up -d
+docker-compose up -d --no-build
 while [ `docker exec -u pbsuser pbs_master pbsnodes -a | grep "Mom = pbs_slave" | wc -l` -ne 2 ]
 do
     echo "Waiting for PBS slave nodes to become available";

--- a/ci/sge/start-sge.sh
+++ b/ci/sge/start-sge.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-docker-compose up -d
+docker-compose up -d --no-build
 while [ `docker exec sge_master qhost | grep lx26-amd64 | wc -l` -ne 2 ]
   do
     echo "Waiting for SGE slots to become available";

--- a/ci/slurm/start-slurm.sh
+++ b/ci/slurm/start-slurm.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-docker-compose up -d
+docker-compose up -d --no-build
 
 while [ `./register_cluster.sh 2>&1 | grep "sacctmgr: error" | wc -l` -ne 0 ]
   do


### PR DESCRIPTION
Now that #455 has been merged, this PR is an attempt at making sure to avoid rebuilding images. The image are currently built via the CI, and we just pull the latest images via ` docker-compose pull`. I got carried away and ended up adding a `mamba` bit in this PR :) With mamba, the conda environment creation takes half the time it used to take:

- Without mamba: `~ 2min 8s`

<img width="1309" alt="Screen Shot 2020-09-29 at 3 05 09 PM" src="https://user-images.githubusercontent.com/13301940/94615945-d2694980-0265-11eb-8c6c-ded8fd78191c.png">


- With mamba: `~ 1min 13s`


<img width="1320" alt="Screen Shot 2020-09-29 at 3 09 02 PM" src="https://user-images.githubusercontent.com/13301940/94615933-ce3d2c00-0265-11eb-8dfe-ca7713ae2c82.png">