### PR TITLE
Modification to run on Summit and support login / batch / compute architecture

### DIFF
--- a/dask_jobqueue/core.py
+++ b/dask_jobqueue/core.py
@@ -59,6 +59,8 @@ job_parameters = """
         Section to use from jobqueue.yaml configuration file.
     name : str
         Name of Dask worker.  This is typically set by the Cluster
+    dask_worker_prefix : str
+        String to prepend to dask_worker_command for environments that have multiple tiers of submittal nodes.  
 """.strip()
 
 
@@ -149,6 +151,7 @@ class Job(ProcessInterface, abc.ABC):
         python=sys.executable,
         job_name=None,
         config_name=None,
+        dask_worker_prefix=None,
     ):
         self.scheduler = scheduler
         self.job_id = None
@@ -237,9 +240,13 @@ class Job(ProcessInterface, abc.ABC):
         self.header_skip = set(header_skip)
 
         # dask-worker command line build
+        
         dask_worker_command = "%(python)s -m distributed.cli.dask_worker" % dict(
             python=python
         )
+        if(dask_worker_prefix) : 
+            dask_worker_command = dask_worker_prefix + " " + dask_worker_command
+
         command_args = [dask_worker_command, self.scheduler]
         command_args += ["--nthreads", self.worker_process_threads]
         if processes is not None and processes > 1:


### PR DESCRIPTION
I am a user on Summit and it uses LSF for job submittal.  It has a unique architecture that has a login / batch / compute node setup such that a job submitted via LSF needs to have this jsrun wrapper script precede any batch job run on cluster as show in this sample job script  (otherwise the job just stays on the batch node and never gets to the compute node).

#!/usr/bin/env bash

#BSUB -J dask-worker
#BSUB -P xxx201
#BSUB -W 00:30
#BSUB -nnodes 1

**jsrun -n1 -a1 -g0 -c1** /ccs/home/vanstee/.conda/envs/powerai-ornl/bin/python -m distributed.cli.dask_worker tcp://10.41.0.33:40063 --nthreads 8 --memory-limit 4.00GB --name dummy-name --nanny --death-timeout 60 --interface ib0 --protocol tcp://

I modified core.py to achieve this goal, and would like to see if some version of this idea could make it into dask_jobqueue library. thanks
