### PR TITLE
Override _new_worker_name to make using Job Arrays easier

### DIFF
--- a/dask_jobqueue/core.py
+++ b/dask_jobqueue/core.py
@@ -589,20 +589,16 @@ class JobQueueCluster(SpecCluster):
     @property
     def job_name(self):
         return self._dummy_job.job_name
-    
+
     def _new_worker_name(self, worker_number):
-        """Provide unique Worker names based on Cluster increment and name.
-        
-        When using Job Arrays, consider adding something analogous to:
-        ```python
-        SLURMCluster(..., name="project-${JOB_ID}", job_extra=["--array=0-50"], env_extra=[
-            "JOB_ID=${SLURM_ARRAY_JOB_ID}_${SLURM_ARRAY_TASK_ID}",
-        ])
-        ```
-        
-        NOTE: When using `.scale` or `.adapt`, jobs will scale by `n_jobs * len(array)`.
+        """Returns new worker name.
+
+        Base worker name on cluster name. This makes it easier to use job
+        arrays within Dask-Jobqueue.
         """
-        return "{name}-{number}".format(name=self._name, number=worker_number)
+        return "{cluster_name}-{worker_number}".format(
+            cluster_name=self._name, worker_number=worker_number
+        )
 
     def scale(self, n=None, jobs=0, memory=None, cores=None):
         """Scale cluster to specified configurations.

--- a/dask_jobqueue/core.py
+++ b/dask_jobqueue/core.py
@@ -589,6 +589,20 @@ class JobQueueCluster(SpecCluster):
     @property
     def job_name(self):
         return self._dummy_job.job_name
+    
+    def _new_worker_name(self, worker_number):
+        """Provide unique Worker names based on Cluster increment and name.
+        
+        When using Job Arrays, consider adding something analogous to:
+        ```python
+        SLURMCluster(..., name="project-${JOB_ID}", job_extra=["--array=0-50"], env_extra=[
+            "JOB_ID=${SLURM_ARRAY_JOB_ID}_${SLURM_ARRAY_TASK_ID}",
+        ])
+        ```
+        
+        NOTE: When using `.scale` or `.adapt`, jobs will scale by `n_jobs * len(array)`.
+        """
+        return "{name}-{number}".format(name=self._name, number=worker_number)
 
     def scale(self, n=None, jobs=0, memory=None, cores=None):
         """Scale cluster to specified configurations.

--- a/dask_jobqueue/tests/test_slurm.py
+++ b/dask_jobqueue/tests/test_slurm.py
@@ -216,6 +216,9 @@ def test_different_interfaces_on_scheduler_and_workers(loop):
 
 @pytest.mark.env("slurm")
 def test_worker_name_uses_cluster_name(loop):
+    # The environment variable setup below is similar to a job array setup
+    # where you would use SLURM_ARRAY_JOB_ID to make sure that Dask workers
+    # belonging to the same job array have different worker names
     with SLURMCluster(
         cores=1,
         memory="2GB",
@@ -230,7 +233,7 @@ def test_worker_name_uses_cluster_name(loop):
             worker_names = [
                 w["id"] for w in client.scheduler_info()["workers"].values()
             ]
-            assert worker_names == [
+            assert sorted(worker_names) == [
                 "test-my-env-variable-value-0",
                 "test-my-env-variable-value-1",
             ]


### PR DESCRIPTION
This is based on what I've found to work on a SLURM cluster (https://openmind.mit.edu) and reported in https://github.com/dask/dask/discussions/7070#discussioncomment-283523 as an attempt to address those errors when submitting Job Arrays, using a variant of https://github.com/dask/dask-jobqueue/issues/196#issuecomment-439745751.