### PR TITLE
Fail early for SGE rather than waiting the CI max time

### DIFF
--- a/ci/sge/start-sge.sh
+++ b/ci/sge/start-sge.sh
@@ -1,9 +1,18 @@
 #!/bin/bash
 
 docker-compose up -d --no-build
+
+START=$(date +%s)
+MAX_WAIT_SECONDS=120
+
 while [ `docker exec sge_master qhost | grep lx26-amd64 | wc -l` -ne 2 ]
-  do
+do
+    if [[ $(($(date +%s) - $START)) -gt $MAX_WAIT_SECONDS ]]; then
+        echo "Exiting after failing to start the cluster in $MAX_WAIT_SECONDS seconds"
+        exit 1
+    fi
     echo "Waiting for SGE slots to become available";
     sleep 1
-  done
+done
+
 echo "SGE properly configured"

--- a/ci/sge/start-sge.sh
+++ b/ci/sge/start-sge.sh
@@ -3,7 +3,7 @@
 docker-compose up -d --no-build
 
 START=$(date +%s)
-MAX_WAIT_SECONDS=120
+MAX_WAIT_SECONDS=300
 
 while [ `docker exec sge_master qhost | grep lx26-amd64 | wc -l` -ne 2 ]
 do


### PR DESCRIPTION
Makes #484 a bit less painful, avoids waiting for 30 minutes which is the max CI build time.