### PR TITLE
Enable support for spaces in project names by enclosing in quotation marks

### DIFF
--- a/dask_jobqueue/lsf.py
+++ b/dask_jobqueue/lsf.py
@@ -71,7 +71,7 @@ class LSFJob(Job):
         if queue is not None:
             header_lines.append("#BSUB -q %s" % queue)
         if project is not None:
-            header_lines.append("#BSUB -P %s" % project)
+            header_lines.append('#BSUB -P "%s"' % project)
         if ncpus is None:
             # Compute default cores specifications
             ncpus = self.worker_cores


### PR DESCRIPTION
Closes https://github.com/dask/dask-jobqueue/issues/494.

**Summary:**
- As per @schmidt73's suggestion, this PR proposes enclosing the project name in quotation marks for `LSFCluster`s, in order to enable support for job submission names containing spaces.