### PR TITLE
WIP: Allow walltime as None to be given during initialization

### DIFF
--- a/dask_jobqueue/sge.py
+++ b/dask_jobqueue/sge.py
@@ -5,6 +5,7 @@ import dask
 from .core import Job, JobQueueCluster, job_parameters, cluster_parameters
 
 logger = logging.getLogger(__name__)
+DEFAULT = "loaded-from-config"
 
 
 class SGEJob(Job):
@@ -19,7 +20,7 @@ class SGEJob(Job):
         queue=None,
         project=None,
         resource_spec=None,
-        walltime="not-set-by-user",
+        walltime=DEFAULT,
         job_extra=None,
         config_name=None,
         **base_class_kwargs
@@ -36,7 +37,7 @@ class SGEJob(Job):
             resource_spec = dask.config.get(
                 "jobqueue.%s.resource-spec" % self.config_name
             )
-        if walltime == "not-set-by-user":
+        if walltime == DEFAULT:
             walltime = dask.config.get("jobqueue.%s.walltime" % self.config_name)
         if job_extra is None:
             job_extra = dask.config.get("jobqueue.%s.job-extra" % self.config_name)

--- a/dask_jobqueue/sge.py
+++ b/dask_jobqueue/sge.py
@@ -19,7 +19,7 @@ class SGEJob(Job):
         queue=None,
         project=None,
         resource_spec=None,
-        walltime=None,
+        walltime="not-set-by-user",
         job_extra=None,
         config_name=None,
         **base_class_kwargs
@@ -36,7 +36,7 @@ class SGEJob(Job):
             resource_spec = dask.config.get(
                 "jobqueue.%s.resource-spec" % self.config_name
             )
-        if walltime is None:
+        if walltime == "not-set-by-user":
             walltime = dask.config.get("jobqueue.%s.walltime" % self.config_name)
         if job_extra is None:
             job_extra = dask.config.get("jobqueue.%s.job-extra" % self.config_name)


### PR DESCRIPTION
Distinguish between None (set by user) and the default value
so `walltime=None` can be set during initilization

Fixes #500