### PR TITLE
feat: Add RemoteSLURMCluster & RemoteSLURMJob #502

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ log
 .cache/
 .pytest_cache
 docs/source/generated
+*.lock
+*.dirlock

--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -4,6 +4,7 @@ channels:
   - defaults
 dependencies:
   - python=3.6
+  - aiohttp
   - dask
   - distributed
   - flake8

--- a/ci/slurm.sh
+++ b/ci/slurm.sh
@@ -26,10 +26,12 @@ function show_network_interfaces {
 
 function jobqueue_install {
     docker exec slurmctld /bin/bash -c "cd /dask-jobqueue; pip install -e ."
+    docker exec slurmrestd /bin/bash -c "cd /dask-jobqueue; pip install -e ."
 }
 
 function jobqueue_script {
     docker exec slurmctld /bin/bash -c "pytest /dask-jobqueue/dask_jobqueue --verbose -E slurm -s"
+    docker exec slurmrestd /bin/bash -c "pytest /dask-jobqueue/dask_jobqueue --verbose -E slurm_remote -s"
 }
 
 function jobqueue_after_script {

--- a/ci/slurm/Dockerfile
+++ b/ci/slurm/Dockerfile
@@ -1,6 +1,29 @@
-FROM alexandervaneck/slurm-docker-cluster:20.11.8.1
+FROM ubuntu:21.04
 
-RUN yum install -y iproute
+# Set debian to non interactive to avoid prompts
+ENV DEBIAN_FRONTEND=noninteractive
+# Setting UTF-8 as default lang
+ENV LC_ALL=C.UTF-8
+ENV LANG=C.UTF-8
+
+## Install python.
+RUN apt-get update && apt-get install -y \
+    # `curl` for downloading miniconda
+    curl \
+    # `gosu` for unpriviledged use
+    gosu \
+    # Slurm (slurmctl & workers)
+    slurm-wlm \
+    # Slurm (slurmdbd) Database
+    slurmdbd \
+    mariadb-server \
+    && \
+    apt autoremove -y && \
+    apt clean && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN mkdir /var/lib/slurmd && chown -R slurm:slurm /var/*/slurm*
+RUN mkdir /run/munge && chown -R munge:munge /run/munge
 
 RUN curl -o miniconda.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh && \
     bash miniconda.sh -f -b -p /opt/anaconda && \
@@ -9,6 +32,8 @@ RUN curl -o miniconda.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-L
 ENV PATH /opt/anaconda/bin:$PATH
 RUN conda install --yes -c conda-forge python=3.6 dask distributed flake8 pytest pytest-asyncio
 
-ENV LC_ALL en_US.UTF-8
+COPY --chown=slurm:slurm slurm.conf /etc/slurm/slurm.conf
+COPY --chown=slurm:slurm slurmdbd.conf /etc/slurm/slurmdbd.conf
 
-COPY slurm.conf /etc/slurm/slurm.conf
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/ci/slurm/Dockerfile
+++ b/ci/slurm/Dockerfile
@@ -1,4 +1,4 @@
-FROM giovtorres/slurm-docker-cluster
+FROM alexandervaneck/slurm-docker-cluster:20.11.8.1
 
 RUN yum install -y iproute
 

--- a/ci/slurm/Dockerfile
+++ b/ci/slurm/Dockerfile
@@ -43,6 +43,7 @@ RUN conda install --yes -c conda-forge python=3.6 dask distributed flake8 pytest
 
 COPY --chown=slurm:slurm slurm.conf /etc/slurm/slurm.conf
 COPY --chown=slurm:slurm slurmdbd.conf /etc/slurm/slurmdbd.conf
+COPY --chown=slurm:slurm slurmrestd.conf /etc/slurm/slurmrestd.conf
 
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/ci/slurm/Dockerfile
+++ b/ci/slurm/Dockerfile
@@ -17,12 +17,16 @@ RUN apt-get update && apt-get install -y \
     # Slurm (slurmdbd) Database
     slurmdbd \
     mariadb-server \
+    # Slurm (slurmrestd) REST API
+    slurmrestd \
     && \
     apt autoremove -y && \
     apt clean && \
     rm -rf /var/lib/apt/lists/*
 
-RUN mkdir /var/lib/slurmd && chown -R slurm:slurm /var/*/slurm*
+# create dir for slurmrestd socket
+RUN mkdir /var/run/slurm && \
+    chown -R slurm:slurm /var/*/slurm*
 RUN mkdir /run/munge && chown -R munge:munge /run/munge
 
 RUN curl -o miniconda.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh && \

--- a/ci/slurm/Dockerfile
+++ b/ci/slurm/Dockerfile
@@ -25,8 +25,13 @@ RUN apt-get update && apt-get install -y \
     rm -rf /var/lib/apt/lists/*
 
 # create dir for slurmrestd socket
-RUN mkdir /var/run/slurm && \
+# Add JWT key to controller in StateSaveLocation
+RUN mkdir /var/run/slurm /var/lib/slurmd && \
+    dd if=/dev/random of=/var/lib/slurmd/jwt_hs256.key bs=32 count=1 && \
+    chown slurm:slurm /var/lib/slurmd/jwt_hs256.key && \
+    chmod 0600 /var/lib/slurmd/jwt_hs256.key && \
     chown -R slurm:slurm /var/*/slurm*
+
 RUN mkdir /run/munge && chown -R munge:munge /run/munge
 
 RUN curl -o miniconda.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh && \

--- a/ci/slurm/docker-compose.yml
+++ b/ci/slurm/docker-compose.yml
@@ -73,7 +73,7 @@ services:
     expose:
       - "6818"
     depends_on:
-      - "slurmdbd"
+      - "slurmctld"
     networks:
       common-network:
         ipv4_address: 10.1.1.13

--- a/ci/slurm/docker-compose.yml
+++ b/ci/slurm/docker-compose.yml
@@ -54,6 +54,32 @@ services:
     cap_add:
       - NET_ADMIN
 
+  slurmrestd:
+    image: daskdev/dask-jobqueue:slurm
+    build: .
+    command: ["slurmrestd"]
+    container_name: slurmrestd
+    hostname: slurmrestd
+    security_opt:
+      # see https://bugs.schedmd.com/show_bug.cgi?id=10949
+      - seccomp=unconfined
+    volumes:
+      - etc_munge:/etc/munge
+      - etc_slurm:/etc/slurm
+      - slurm_jobdir:/data
+      - var_log_slurm:/var/log/slurm
+      - var_run_slurm:/var/run/slurm
+      - ../..:/dask-jobqueue
+    expose:
+      - "6818"
+    depends_on:
+      - "slurmdbd"
+    networks:
+      common-network:
+        ipv4_address: 10.1.1.13
+    cap_add:
+      - NET_ADMIN
+
   c1:
     image: daskdev/dask-jobqueue:slurm
     build: .
@@ -102,6 +128,7 @@ volumes:
   slurm_jobdir:
   var_lib_mysql:
   var_log_slurm:
+  var_run_slurm:
 
 networks:
   common-network:

--- a/ci/slurm/entrypoint.sh
+++ b/ci/slurm/entrypoint.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+set -e
+
+if [ "$1" = "slurmdbd" ]
+then
+    echo "---> Starting the MUNGE Authentication service (munged) ..."
+    gosu munge /etc/init.d/munge start
+
+    echo "---> Starting the Slurm Database Daemon (slurmdbd) ..."
+
+    {
+        . /etc/slurm/slurmdbd.conf
+        until echo "SELECT 1" | mysql -h $StorageHost -u$StorageUser -p$StoragePass 2>&1 > /dev/null
+        do
+            echo "-- Waiting for database to become active ..."
+            sleep 2
+        done
+    }
+    echo "-- Database is now active ..."
+
+    echo "---> Starting the Slurm Database Daemon (slurmdbd) ..."
+    gosu slurm slurmdbd -Dvvv
+fi
+
+if [ "$1" = "slurmctld" ]
+then
+    echo "---> Starting the MUNGE Authentication service (munged) ..."
+    gosu munge /etc/init.d/munge start
+
+    echo "---> Waiting for slurmdbd to become active before starting slurmctld ..."
+
+    until 2>/dev/null >/dev/tcp/slurmdbd/6819
+    do
+        echo "-- slurmdbd is not available.  Sleeping ..."
+        sleep 2
+    done
+    echo "-- slurmdbd is now active ..."
+
+    echo "---> Starting the Slurm Controller Daemon (slurmctld) ..."
+    gosu slurm slurmctld -Dvvv
+fi
+
+if [ "$1" = "slurmd" ]
+then
+    echo "---> Starting the MUNGE Authentication service (munged) ..."
+    gosu munge /etc/init.d/munge start
+
+    echo "---> Waiting for slurmctld to become active before starting slurmd..."
+
+    until 2>/dev/null >/dev/tcp/slurmctld/6817
+    do
+        echo "-- slurmctld is not available.  Sleeping ..."
+        sleep 2
+    done
+    echo "-- slurmctld is now active ..."
+
+    echo "---> Starting the Slurm Node Daemon (slurmd) ..."
+    slurmd -Dvvv
+fi
+
+exec "$@"

--- a/ci/slurm/entrypoint.sh
+++ b/ci/slurm/entrypoint.sh
@@ -55,7 +55,7 @@ then
     echo "-- slurmdbd is now active ..."
 
     echo "---> Starting the Slurm REST API Daemon (slurmrestd) ..."
-    gosu slurm slurmrestd unix:/var/run/slurm/slurmrestd.socket -a rest_auth/local -vvvvvv
+    gosu slurm slurmrestd unix:/var/run/slurm/slurmrestd.socket -a rest_auth/local -vvvvvv & gosu slurm slurmrestd 0.0.0.0:6818 -a rest_auth/jwt -vvvvvv
 fi
 
 if [ "$1" = "slurmd" ]

--- a/ci/slurm/entrypoint.sh
+++ b/ci/slurm/entrypoint.sh
@@ -45,17 +45,17 @@ then
     echo "---> Starting the MUNGE Authentication service (munged) ..."
     gosu munge /etc/init.d/munge start
 
-    echo "---> Waiting for slurmdbd to become active before starting slurmctld ..."
+    echo "---> Waiting for slurmctld to become active before starting slurmrestd..."
 
-    until 2>/dev/null >/dev/tcp/slurmdbd/6819
+    until 2>/dev/null >/dev/tcp/slurmctld/6817
     do
-        echo "-- slurmdbd is not available.  Sleeping ..."
+        echo "-- slurmctld is not available.  Sleeping ..."
         sleep 2
     done
-    echo "-- slurmdbd is now active ..."
+    echo "-- slurmctld is now active ..."
 
     echo "---> Starting the Slurm REST API Daemon (slurmrestd) ..."
-    gosu slurm slurmrestd unix:/var/run/slurm/slurmrestd.socket -a rest_auth/local -vvvvvv & gosu slurm slurmrestd 0.0.0.0:6818 -a rest_auth/jwt -vvvvvv
+    gosu slurm slurmrestd unix:/var/run/slurm/slurmrestd.socket -a rest_auth/local -vvvvvv & gosu slurm slurmrestd 0.0.0.0:6818 -f /etc/slurm/slurmrestd.conf -vvvvvv
 fi
 
 if [ "$1" = "slurmd" ]

--- a/ci/slurm/entrypoint.sh
+++ b/ci/slurm/entrypoint.sh
@@ -40,6 +40,24 @@ then
     gosu slurm slurmctld -Dvvv
 fi
 
+if [ "$1" = "slurmrestd" ]
+then
+    echo "---> Starting the MUNGE Authentication service (munged) ..."
+    gosu munge /etc/init.d/munge start
+
+    echo "---> Waiting for slurmdbd to become active before starting slurmctld ..."
+
+    until 2>/dev/null >/dev/tcp/slurmdbd/6819
+    do
+        echo "-- slurmdbd is not available.  Sleeping ..."
+        sleep 2
+    done
+    echo "-- slurmdbd is now active ..."
+
+    echo "---> Starting the Slurm REST API Daemon (slurmrestd) ..."
+    gosu slurm slurmrestd unix:/var/run/slurm/slurmrestd.socket -a rest_auth/local -vvvvvv
+fi
+
 if [ "$1" = "slurmd" ]
 then
     echo "---> Starting the MUNGE Authentication service (munged) ..."

--- a/ci/slurm/slurm.conf
+++ b/ci/slurm/slurm.conf
@@ -58,7 +58,6 @@ SchedulerType=sched/backfill
 #SchedulerRootFilter=
 SelectType=select/cons_res
 SelectTypeParameters=CR_CPU_Memory
-FastSchedule=1
 #PriorityType=priority/multifactor
 #PriorityDecayHalfLife=14-0
 #PriorityUsageResetPeriod=14-0

--- a/ci/slurm/slurm.conf
+++ b/ci/slurm/slurm.conf
@@ -90,3 +90,7 @@ NodeName=c[1-2] RealMemory=4096 CPUs=2 State=UNKNOWN
 #
 # PARTITIONS
 PartitionName=normal Default=yes Nodes=c[1-2] Priority=50 DefMemPerCPU=2048 Shared=NO MaxNodes=2 MaxTime=5-00:00:00 DefaultTime=5-00:00:00 State=UP
+
+# REST API
+AuthAltTypes=auth/jwt
+AuthAltParameters=jwt_key=/var/lib/slurmd/jwt_hs256.key

--- a/ci/slurm/slurm.conf
+++ b/ci/slurm/slurm.conf
@@ -83,7 +83,6 @@ JobAcctGatherFrequency=30
 AccountingStorageType=accounting_storage/slurmdbd
 AccountingStorageHost=slurmdbd
 AccountingStoragePort=6819
-AccountingStorageLoc=slurm_acct_db
 #AccountingStoragePass=
 #AccountingStorageUser=
 #

--- a/ci/slurm/slurmdbd.conf
+++ b/ci/slurm/slurmdbd.conf
@@ -31,3 +31,7 @@ StorageHost=mysql
 StorageUser=slurm
 StoragePass=password
 StorageLoc=slurm_acct_db
+
+# REST API
+AuthAltTypes=auth/jwt
+AuthAltParameters=jwt_key=/var/lib/slurmd/jwt_hs256.key

--- a/ci/slurm/slurmdbd.conf
+++ b/ci/slurm/slurmdbd.conf
@@ -1,0 +1,33 @@
+#
+# Example slurmdbd.conf file.
+#
+# See the slurmdbd.conf man page for more information.
+#
+# Archive info
+#ArchiveJobs=yes
+#ArchiveDir="/tmp"
+#ArchiveSteps=yes
+#ArchiveScript=
+#JobPurge=12
+#StepPurge=1
+#
+# slurmDBD info
+DbdAddr=slurmdbd
+DbdHost=slurmdbd
+#DbdPort=6819
+SlurmUser=slurm
+#MessageTimeout=300
+DebugLevel=4
+#DefaultQOS=normal,standby
+LogFile=/var/log/slurm/slurmdbd.log
+PidFile=/var/run/slurmdbd/slurmdbd.pid
+#PluginDir=/usr/lib/slurm
+#PrivateData=accounts,users,usage,jobs
+#TrackWCKey=yes
+#
+# Database info
+StorageType=accounting_storage/mysql
+StorageHost=mysql
+StorageUser=slurm
+StoragePass=password
+StorageLoc=slurm_acct_db

--- a/ci/slurm/slurmrestd.conf
+++ b/ci/slurm/slurmrestd.conf
@@ -1,0 +1,2 @@
+include /etc/slurm/slurm.conf
+AuthType=auth/jwt

--- a/ci/slurm/start-slurm.sh
+++ b/ci/slurm/start-slurm.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-docker-compose up -d --no-build
+docker-compose up -d --build
 
 while [ `./register_cluster.sh 2>&1 | grep "sacctmgr: error" | wc -l` -ne 0 ]
   do

--- a/dask_jobqueue/__init__.py
+++ b/dask_jobqueue/__init__.py
@@ -3,6 +3,7 @@ from . import config
 from .core import JobQueueCluster
 from .moab import MoabCluster
 from .pbs import PBSCluster
+from .remote_slurm import RemoteSLURMCluster
 from .slurm import SLURMCluster
 from .sge import SGECluster
 from .lsf import LSFCluster

--- a/dask_jobqueue/core.py
+++ b/dask_jobqueue/core.py
@@ -106,6 +106,7 @@ class Job(ProcessInterface, abc.ABC):
     --------
     PBSCluster
     SLURMCluster
+    RemoteSLURMCluster
     SGECluster
     OARCluster
     LSFCluster
@@ -413,8 +414,8 @@ class JobQueueCluster(SpecCluster):
     __doc__ = """ Deploy Dask on a Job queuing system
 
     This is a superclass, and is rarely used directly.  It is more common to
-    use an object like SGECluster, SLURMCluster, PBSCluster, LSFCluster, or
-    others.
+    use an object like SGECluster, SLURMCluster, RemoteSLURMCluster, PBSCluster,
+     LSFCluster, or others.
 
     However, it can be used directly if you have a custom ``Job`` type.
     This class relies heavily on being passed a ``Job`` type that is able to

--- a/dask_jobqueue/remote_slurm.py
+++ b/dask_jobqueue/remote_slurm.py
@@ -38,10 +38,10 @@ class RemoteSLURMJob(SLURMJob):
         if self.log_directory is not None:
             configuration[
                 "standard_error"
-            ] = f"{self.log_directory}/{self.job_name or 'worker'}-%%J.err"
+            ] = f"{self.log_directory}/{self.job_name or 'worker'}-%J.err"
             configuration[
                 "standard_output"
-            ] = f"{self.log_directory}/{self.job_name or 'worker'}-%%J.out"
+            ] = f"{self.log_directory}/{self.job_name or 'worker'}-%J.out"
         if self.queue is not None:
             configuration["partition"] = self.queue
         if self.project is not None:

--- a/dask_jobqueue/remote_slurm.py
+++ b/dask_jobqueue/remote_slurm.py
@@ -169,4 +169,27 @@ class RemoteSLURMCluster(SLURMCluster):
             **kwargs,
         )
 
+    @classmethod
+    def with_http_api_client(
+        cls,
+        http_api_url: str,
+        http_api_user_name: str,
+        http_api_user_token: str,
+        *args,
+        **kwargs,
+    ) -> "RemoteSLURMCluster":
+        kwargs["api_url"] = (
+            http_api_url if http_api_url.endswith("/") else f"{http_api_url}/"
+        )
+        return cls(
+            api_client_session_kwargs=dict(
+                headers={
+                    "X-SLURM-USER-NAME": http_api_user_name,
+                    "X-SLURM-USER-TOKEN": http_api_user_token,
+                }
+            ),
+            *args,
+            **kwargs,
+        )
+
     job_cls = RemoteSLURMJob

--- a/dask_jobqueue/remote_slurm.py
+++ b/dask_jobqueue/remote_slurm.py
@@ -1,7 +1,6 @@
 import logging
 from contextlib import contextmanager
-from typing import Any, Dict, Generator
-from urllib.parse import urljoin
+from typing import Any, Dict
 
 import aiohttp
 

--- a/dask_jobqueue/remote_slurm.py
+++ b/dask_jobqueue/remote_slurm.py
@@ -68,7 +68,6 @@ class RemoteSLURMJob(SLURMJob):
         response = await client_session.post(
             f"{self.api_url}slurm/v0.0.36/job/submit",
             json={"script": script, "job": self._job_configuration},
-            raise_for_status=False,
         )
         async with response:
             return await response.json()
@@ -86,7 +85,6 @@ class RemoteSLURMJob(SLURMJob):
         )
         response = await client_session.delete(
             f"{self.api_url}slurm/v0.0.36/job/{self.job_id}",
-            raise_for_status=False,
         )
         async with response:
             return await response.json()

--- a/dask_jobqueue/remote_slurm.py
+++ b/dask_jobqueue/remote_slurm.py
@@ -102,9 +102,9 @@ class RemoteSLURMCluster(SLURMCluster):
 
     Parameters
     ----------
-    api_url: str
-        A url (ending in /) pointing to the SLURM REST API
-        See https://slurm.schedmd.com/rest_api.html
+    api_client_session_kwargs: Dict
+        A dictionary with key/values for aiohttp.ClientSession. to set up a client session 
+        with specific headers or connectors.
     queue : str
         Destination queue for each worker job. Passed to `#SBATCH -p` option.
     project : str
@@ -125,7 +125,9 @@ class RemoteSLURMCluster(SLURMCluster):
     --------
     >>> from dask_jobqueue import SLURMCluster
     >>> cluster = RemoteSLURMCluster(
-    ...     api_socket_path='/var/run/slurmrestd.socket.',
+    ...     api_client_session_kwargs=dict(
+                connector=aiohttp.UnixConnector(path='/path/to/slurmrestd.socket')
+            ),
     ...     queue='regular',
     ...     project="myproj",
     ...     cores=24,

--- a/dask_jobqueue/remote_slurm.py
+++ b/dask_jobqueue/remote_slurm.py
@@ -1,0 +1,119 @@
+import logging
+from contextlib import contextmanager
+from urllib.parse import urljoin
+
+import aiohttp
+
+from .core import cluster_parameters, job_parameters
+from .slurm import SLURMCluster, SLURMJob
+
+logger = logging.getLogger(__name__)
+
+
+class RemoteSLURMJob(SLURMJob):
+    def __init__(self, *args, **kwargs):
+        self.api_url = kwargs.pop("api_url")
+        self.__class__.api_url = self.api_url
+        super().__init__(*args, **kwargs)
+
+    @contextmanager
+    def job_file(self):
+        """
+        Override the job_file and pass back the job_script. job_file() is used by Job.start and
+         gives output directly to SLURMJob._submit_job().
+        """
+        yield self.job_script()
+
+    async def _submit_job(self, script):
+        # https://slurm.schedmd.com/rest_api.html#slurmctldSubmitJob
+        try:
+            async with aiohttp.ClientSession() as session:
+                response = await session.post(
+                    urljoin(self.api_url, "jobs/submit"), json={"script": script}
+                )
+                response.raise_for_status()
+        except aiohttp.ClientResponseError as e:
+            logger.exception("SLURMJob request failed.")
+            raise RuntimeError from e
+        else:
+            return response.json()
+
+    def _job_id_from_submit_output(self, out):
+        # out is the JSON output from _submit_job request.post
+        # See https://slurm.schedmd.com/rest_api.html#v0.0.36_job_submission_response
+        return out["job_id"]
+
+    async def close(self):
+        logger.debug("Stopping worker: %s job: %s", self.name, self.job_id)
+        # https://slurm.schedmd.com/rest_api.html#slurmctldCancelJob
+        try:
+            async with aiohttp.ClientSession() as session:
+                response = await session.delete(
+                    urljoin(self.api_url, f"job/{self.job_id}")
+                )
+                response.raise_for_status()
+        except aiohttp.ClientResponseError as e:
+            logger.exception("SLURMJob request failed.")
+            raise RuntimeError from e
+        else:
+            return response
+
+    @classmethod
+    def _close_job(cls, job_id):
+        # Overriding to please weakref in Job.start, not used.
+        pass
+
+
+class RemoteSLURMCluster(SLURMCluster):
+    __doc__ = """ Launch Dask on a SLURM cluster
+
+    Parameters
+    ----------
+    api_url: str
+        A url (ending in /) pointing to the SLURM REST API
+        See https://slurm.schedmd.com/rest_api.html
+    queue : str
+        Destination queue for each worker job. Passed to `#SBATCH -p` option.
+    project : str
+        Accounting string associated with each worker job. Passed to `#SBATCH -A` option.
+    {job}
+    {cluster}
+    walltime : str
+        Walltime for each worker job.
+    job_cpu : int
+        Number of cpu to book in SLURM, if None, defaults to worker `threads * processes`
+    job_mem : str
+        Amount of memory to request in SLURM. If None, defaults to worker
+        processes * memory
+    job_extra : list
+        List of other Slurm options, for example -j oe. Each option will be prepended with the #SBATCH prefix.
+
+    Examples
+    --------
+    >>> from dask_jobqueue import SLURMCluster
+    >>> cluster = RemoteSLURMCluster(
+    ...     api_url='http://a-url.com/slurm/',
+    ...     queue='regular',
+    ...     project="myproj",
+    ...     cores=24,
+    ...     memory="500 GB"
+    ... )
+    >>> cluster.scale(jobs=10)  # ask for 10 jobs
+
+    >>> from dask.distributed import Client
+    >>> client = Client(cluster)
+
+    This also works with adaptive clusters.  This automatically launches and kill workers based on load.
+
+    >>> cluster.adapt(maximum_jobs=20)
+    """.format(
+        job=job_parameters, cluster=cluster_parameters
+    )
+
+    def __init__(self, *args, **kwargs):
+        if "api_url" not in kwargs:
+            raise ValueError("api_url is missing from RemoteSlurmCluster.")
+
+        super().__init__(*args, **kwargs)
+
+    job_cls = RemoteSLURMJob

--- a/dask_jobqueue/remote_slurm.py
+++ b/dask_jobqueue/remote_slurm.py
@@ -62,6 +62,7 @@ class RemoteSLURMJob(SLURMJob):
 
     async def _submit_job(self, script):
         # https://slurm.schedmd.com/rest_api.html#slurmctldSubmitJob
+        logger.debug(f'Sending script to SLURM API: {script}')
         async with aiohttp.ClientSession(
             raise_for_status=True, **self.api_client_session_kwargs
         ) as client_session:
@@ -80,6 +81,7 @@ class RemoteSLURMJob(SLURMJob):
     def _job_id_from_submit_output(self, out):
         # out is the JSON output from _submit_job request.post
         # See https://slurm.schedmd.com/rest_api.html#v0.0.36_job_submission_response
+        logger.debug(f'SLURM API responded: {out}.')
         return out["job_id"]
 
     async def close(self):

--- a/dask_jobqueue/remote_slurm.py
+++ b/dask_jobqueue/remote_slurm.py
@@ -32,7 +32,7 @@ class RemoteSLURMJob(SLURMJob):
                     urljoin(self.api_url, "jobs/submit"), json={"script": script}
                 )
                 response.raise_for_status()
-        except aiohttp.ClientResponseError as e:
+        except aiohttp.ClientError as e:
             logger.exception("SLURMJob request failed.")
             raise RuntimeError from e
         else:
@@ -52,7 +52,7 @@ class RemoteSLURMJob(SLURMJob):
                     urljoin(self.api_url, f"job/{self.job_id}")
                 )
                 response.raise_for_status()
-        except aiohttp.ClientResponseError as e:
+        except aiohttp.ClientError as e:
             logger.exception("SLURMJob request failed.")
             raise RuntimeError from e
         else:

--- a/dask_jobqueue/remote_slurm.py
+++ b/dask_jobqueue/remote_slurm.py
@@ -14,9 +14,7 @@ class RemoteSLURMJob(SLURMJob):
     def __init__(self, *args, **kwargs):
         self.api_client_session_kwargs = kwargs.pop("api_client_session_kwargs")
         self.api_url = kwargs.pop("api_url")
-        self.remote_job_extra = (
-            kwargs.pop("remote_job_extra") if "remote_job_extra" in kwargs else {}
-        )
+        self.remote_job_extra = kwargs.pop("remote_job_extra", {})
         super().__init__(*args, **kwargs)
 
     @contextmanager

--- a/dask_jobqueue/remote_slurm.py
+++ b/dask_jobqueue/remote_slurm.py
@@ -65,6 +65,11 @@ class RemoteSLURMJob(SLURMJob):
         client_session = aiohttp.ClientSession(
             raise_for_status=True, **self.api_client_session_kwargs
         )
+        # Unfortunately for certain message (like Authentication Failure) SLURM
+        # will respond with a 'Content-Type' of application/json but then the response will
+        # not be parsable JSON.
+        # This now only works if we set `AIOHTTP_NO_EXTENSIONS=1`
+        # See https://github.com/aio-libs/aiohttp/issues/1843
         response = await client_session.post(
             f"{self.api_url}slurm/v0.0.36/job/submit",
             json={"script": script, "job": self._job_configuration},

--- a/dask_jobqueue/remote_slurm.py
+++ b/dask_jobqueue/remote_slurm.py
@@ -103,8 +103,8 @@ class RemoteSLURMCluster(SLURMCluster):
     Parameters
     ----------
     api_client_session_kwargs: Dict
-        A dictionary with key/values for aiohttp.ClientSession. to set up a client session 
-        with specific headers or connectors.
+        A dictionary with key/values for aiohttp.ClientSession. to set up a client session
+         with specific headers or connectors.
     queue : str
         Destination queue for each worker job. Passed to `#SBATCH -p` option.
     project : str

--- a/dask_jobqueue/remote_slurm.py
+++ b/dask_jobqueue/remote_slurm.py
@@ -62,9 +62,9 @@ class RemoteSLURMJob(SLURMJob):
 
     async def _submit_job(self, script):
         # https://slurm.schedmd.com/rest_api.html#slurmctldSubmitJob
-        logger.debug(f"Sending script to SLURM API: {script}")
+        logger.debug(f'Sending script to SLURM API: {script}')
         async with aiohttp.ClientSession(
-            **self.api_client_session_kwargs
+            raise_for_status=True, **self.api_client_session_kwargs
         ) as client_session:
             # Unfortunately for certain message (like Authentication Failure) SLURM
             # will respond with a 'Content-Type' of application/json but then the response will
@@ -76,37 +76,25 @@ class RemoteSLURMJob(SLURMJob):
                 json={"script": script, "job": self._job_configuration},
             )
             async with response:
-                try:
-                    response.raise_for_status()
-                except aiohttp.ClientResponseError:
-                    body = await response.read()
-                    logger.exception(f"Request failed, response: {body}")
-                else:
-                    return await response.json()
+                return await response.json()
 
     def _job_id_from_submit_output(self, out):
         # out is the JSON output from _submit_job request.post
         # See https://slurm.schedmd.com/rest_api.html#v0.0.36_job_submission_response
-        logger.debug(f"SLURM API responded: {out}.")
+        logger.debug(f'SLURM API responded: {out}.')
         return out["job_id"]
 
     async def close(self):
         logger.debug("Stopping worker: %s job: %s", self.name, self.job_id)
         # https://slurm.schedmd.com/rest_api.html#slurmctldCancelJob
         async with aiohttp.ClientSession(
-            **self.api_client_session_kwargs
+            raise_for_status=True, **self.api_client_session_kwargs
         ) as client_session:
             response = await client_session.delete(
                 f"{self.api_url}slurm/v0.0.36/job/{self.job_id}",
             )
             async with response:
-                try:
-                    response.raise_for_status()
-                except aiohttp.ClientResponseError:
-                    body = await response.read()
-                    logger.exception(f"Request failed, response: {body}")
-                else:
-                    return await response.json()
+                return await response.json()
 
     @classmethod
     def _close_job(cls, job_id):

--- a/dask_jobqueue/slurm.py
+++ b/dask_jobqueue/slurm.py
@@ -74,11 +74,11 @@ class SLURMJob(Job):
             "#SBATCH --cpus-per-task=%d" % (self.job_cpu or self.worker_cores)
         )
         # Memory
-        self.memory = self.job_mem
+        memory = self.job_mem
         if self.job_mem is None:
-            self.memory = slurm_format_bytes_ceil(self.worker_memory)
-        if self.memory is not None:
-            header_lines.append("#SBATCH --mem=%s" % self.memory)
+            memory = slurm_format_bytes_ceil(self.worker_memory)
+        if memory is not None:
+            header_lines.append("#SBATCH --mem=%s" % memory)
 
         if self.walltime is not None:
             header_lines.append("#SBATCH -t %s" % self.walltime)

--- a/dask_jobqueue/tests/test_remote_slurm.py
+++ b/dask_jobqueue/tests/test_remote_slurm.py
@@ -1,0 +1,80 @@
+from time import sleep, time
+from typing import Dict
+
+import pytest
+from distributed import Client
+
+from dask_jobqueue.remote_slurm import RemoteSLURMCluster
+from . import QUEUE_WAIT
+
+TEST_SOCKET_API_PATH = "/var/run/slurm/slurmrestd.socket"
+
+
+@pytest.fixture(scope="session")
+def api_credentials() -> Dict[str, str]:
+    return {
+        "api_socket_path": TEST_SOCKET_API_PATH,
+    }
+
+
+@pytest.mark.env("slurm_socket")
+def test_basic(loop, api_credentials):
+    with RemoteSLURMCluster(
+        **api_credentials,
+        cores=1,
+        # processes=1,
+        memory="2GB",
+        loop=loop,
+        log_directory="/var/log/slurm",
+        local_directory="/tmp",
+    ) as cluster:
+        with Client(cluster, loop=loop) as client:
+            print("Scaling...")
+            cluster.scale(1)
+            print("Starting scale wait...")
+            client.wait_for_workers(1)
+
+            print("Submitting func...")
+            future = client.submit(lambda x: x + 1, 10)
+            assert future.result(QUEUE_WAIT) == 11
+
+            workers = list(client.scheduler_info()["workers"].values())
+            w = workers[0]
+            assert w["memory_limit"] == 2e9
+            assert w["nthreads"] == 1
+
+            print("Scaling down...")
+            cluster.scale(0)
+
+            start = time()
+            print("Starting wait for scale down...")
+            while client.scheduler_info()["workers"]:
+                sleep(0.100)
+                assert time() < start + QUEUE_WAIT
+
+
+@pytest.mark.env("slurm_socket")
+def test_adaptive(loop, api_credentials):
+    with RemoteSLURMCluster(
+        **api_credentials,
+        cores=1,
+        # processes=1,
+        memory="2GB",
+        loop=loop,
+        log_directory="/var/log/slurm",
+        local_directory="/tmp",
+    ) as cluster:
+        cluster.adapt()
+        with Client(cluster) as client:
+            future = client.submit(lambda x: x + 1, 10)
+
+            client.wait_for_workers(1)
+
+            assert future.result(QUEUE_WAIT) == 11
+
+            del future
+
+            start = time()
+            while client.scheduler_info()["workers"]:
+                sleep(0.100)
+                assert time() < start + QUEUE_WAIT

--- a/dask_jobqueue/tests/test_remote_slurm.py
+++ b/dask_jobqueue/tests/test_remote_slurm.py
@@ -79,12 +79,9 @@ def remote_cluster(request):
 def test_basic(loop, remote_cluster):
     with remote_cluster as cluster:
         with Client(cluster, loop=loop) as client:
-            print("Scaling...")
             cluster.scale(2)
-            print("Starting scale wait...")
             client.wait_for_workers(2)
 
-            print("Submitting func...")
             future = client.submit(lambda x: x + 1, 10)
             assert future.result(QUEUE_WAIT) == 11
 
@@ -93,11 +90,9 @@ def test_basic(loop, remote_cluster):
             assert w["memory_limit"] == 2e9
             assert w["nthreads"] == 2
 
-            print("Scaling down...")
             cluster.scale(0)
 
             start = time()
-            print("Starting wait for scale down...")
             while client.scheduler_info()["workers"]:
                 sleep(0.100)
                 assert time() < start + QUEUE_WAIT

--- a/dask_jobqueue/tests/test_remote_slurm.py
+++ b/dask_jobqueue/tests/test_remote_slurm.py
@@ -1,5 +1,4 @@
 from time import sleep, time
-from typing import Dict
 
 import pytest
 from distributed import Client
@@ -10,29 +9,33 @@ from . import QUEUE_WAIT
 TEST_SOCKET_API_PATH = "/var/run/slurm/slurmrestd.socket"
 
 
-@pytest.fixture(scope="session")
-def api_credentials() -> Dict[str, str]:
-    return {
-        "api_socket_path": TEST_SOCKET_API_PATH,
-    }
-
-
-@pytest.mark.env("slurm_socket")
-def test_basic(loop, api_credentials):
-    with RemoteSLURMCluster(
-        **api_credentials,
-        cores=1,
-        # processes=1,
+@pytest.fixture
+def socket_slurm_cluster(loop):
+    return RemoteSLURMCluster.with_socket_api_client(
+        socket_api_path=TEST_SOCKET_API_PATH,
+        cores=2,
+        processes=1,
         memory="2GB",
+        job_mem="2GB",
         loop=loop,
         log_directory="/var/log/slurm",
         local_directory="/tmp",
-    ) as cluster:
+    )
+
+
+@pytest.fixture(params=["socket_slurm_cluster"])
+def remote_cluster(request):
+    return request.getfixturevalue(request.param)
+
+
+@pytest.mark.env("slurm_remote")
+def test_basic(loop, remote_cluster):
+    with remote_cluster as cluster:
         with Client(cluster, loop=loop) as client:
             print("Scaling...")
-            cluster.scale(1)
+            cluster.scale(2)
             print("Starting scale wait...")
-            client.wait_for_workers(1)
+            client.wait_for_workers(2)
 
             print("Submitting func...")
             future = client.submit(lambda x: x + 1, 10)
@@ -41,7 +44,7 @@ def test_basic(loop, api_credentials):
             workers = list(client.scheduler_info()["workers"].values())
             w = workers[0]
             assert w["memory_limit"] == 2e9
-            assert w["nthreads"] == 1
+            assert w["nthreads"] == 2
 
             print("Scaling down...")
             cluster.scale(0)
@@ -53,17 +56,9 @@ def test_basic(loop, api_credentials):
                 assert time() < start + QUEUE_WAIT
 
 
-@pytest.mark.env("slurm_socket")
-def test_adaptive(loop, api_credentials):
-    with RemoteSLURMCluster(
-        **api_credentials,
-        cores=1,
-        # processes=1,
-        memory="2GB",
-        loop=loop,
-        log_directory="/var/log/slurm",
-        local_directory="/tmp",
-    ) as cluster:
+@pytest.mark.env("slurm_remote")
+def test_adaptive(loop, remote_cluster):
+    with remote_cluster as cluster:
         cluster.adapt()
         with Client(cluster) as client:
             future = client.submit(lambda x: x + 1, 10)

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -15,4 +15,5 @@ API
    OARCluster
    PBSCluster
    SGECluster
+   RemoteSLURMCluster
    SLURMCluster

--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -180,3 +180,27 @@ specified for certain steps in the processing. For example:
     result_stage_2 = client.compute(stage_2,
                                     resources={tuple(stage_1): {'GPU': 1},
                                                tuple(stage_2): {'ssdGB': 100}})
+Remote SLURM Deployment
+-----------------
+
+All the above SLURMCluster examples are also possible over the SLURM REST API with the use of
+RemoteSlurmCluster. See https://slurm.schedmd.com/rest_api.html for more information.
+
+This only works for environments where the scheduler is able to communicate with the SLURM REST API
+and the workers get scheduled on SLURM nodes that also can communicate with the scheduler.
+(f.e. the scheduler is inside a docker container but still within the HPC cluster network)
+
+.. code-block:: python
+
+   from dask_jobqueue import RemoteSLURMCluster
+
+   cluster = RemoteSLURMCluster(
+                          api_url='http://<your-slurm-http-rest-api-url>/',
+                          cores=8,
+                          processes=4,
+                          memory="16GB",
+                          project="woodshole",
+                          walltime="01:00:00",
+                          queue="normal")
+
+

--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -190,12 +190,16 @@ This only works for environments where the scheduler is able to communicate with
 and the workers get scheduled on SLURM nodes that also can communicate with the scheduler.
 (f.e. the scheduler is inside a docker container but still within the HPC cluster network)
 
+Currently slurmrestd only supports 2 authentication methods; Unix socket auth and JWT auth.
+
+Unix socket authentication:
+
 .. code-block:: python
 
    from dask_jobqueue import RemoteSLURMCluster
 
-   cluster = RemoteSLURMCluster(
-                          api_url='http://<your-slurm-http-rest-api-url>/',
+   cluster = RemoteSLURMCluster.with_socket_api_client(
+                          socket_api_path='/var/run/slurmrestd.socket',
                           cores=8,
                           processes=4,
                           memory="16GB",
@@ -203,4 +207,44 @@ and the workers get scheduled on SLURM nodes that also can communicate with the 
                           walltime="01:00:00",
                           queue="normal")
 
+HTTP JWT Authentication:
+
+To generate a token see https://slurm.schedmd.com/jwt.html.
+
+.. code-block:: python
+
+   from dask_jobqueue import RemoteSLURMCluster
+
+   cluster = RemoteSLURMCluster.with_http_api_client(
+                          http_api_url='<host:port>',
+                          http_api_user_name='slurm',
+                          http_api_user_token='<a token>',
+                          cores=8,
+                          processes=4,
+                          memory="16GB",
+                          project="woodshole",
+                          walltime="01:00:00",
+                          queue="normal")
+
+It's also possible to set other headers or authentication methods if slurmrestd starts supporting
+these in the future. The `api_client_session_kwargs` will be passed to aihttp.ClientSession to
+instantiate an authenticated session.
+
+.. code-block:: python
+
+   from dask_jobqueue import RemoteSLURMCluster
+
+   cluster = RemoteSLURMCluster(
+                          api_client_session_kwargs=dict(
+                                headers={
+                                    "X-SLURM-USER-NAME": http_api_user_name,
+                                    "X-SLURM-USER-TOKEN": http_api_user_token,
+                                }
+                            ),
+                            cores=8,
+                            processes=4,
+                            memory="16GB",
+                            project="woodshole",
+                            walltime="01:00:00",
+                            queue="normal")
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,6 @@
 -r ./requirements.txt
+black
+flake8
 pre-commit
+pytest
+pytest-asyncio

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 dask>=2.19
 distributed>=2.19
+aiohttp>=3.7

--- a/versioneer.py
+++ b/versioneer.py
@@ -1,4 +1,3 @@
-
 # Version: 0.18
 
 """The Versioneer - like a rocketeer, but for versions.
@@ -310,11 +309,13 @@ def get_root():
         setup_py = os.path.join(root, "setup.py")
         versioneer_py = os.path.join(root, "versioneer.py")
     if not (os.path.exists(setup_py) or os.path.exists(versioneer_py)):
-        err = ("Versioneer was unable to run the project root directory. "
-               "Versioneer requires setup.py to be executed from "
-               "its immediate directory (like 'python setup.py COMMAND'), "
-               "or in a way that lets it use sys.argv[0] to find the root "
-               "(like 'python path/to/setup.py COMMAND').")
+        err = (
+            "Versioneer was unable to run the project root directory. "
+            "Versioneer requires setup.py to be executed from "
+            "its immediate directory (like 'python setup.py COMMAND'), "
+            "or in a way that lets it use sys.argv[0] to find the root "
+            "(like 'python path/to/setup.py COMMAND')."
+        )
         raise VersioneerBadRootError(err)
     try:
         # Certain runtime workflows (setup.py install/develop in a setuptools
@@ -327,8 +328,10 @@ def get_root():
         me_dir = os.path.normcase(os.path.splitext(me)[0])
         vsr_dir = os.path.normcase(os.path.splitext(versioneer_py)[0])
         if me_dir != vsr_dir:
-            print("Warning: build in %s is using versioneer.py from %s"
-                  % (os.path.dirname(me), versioneer_py))
+            print(
+                "Warning: build in %s is using versioneer.py from %s"
+                % (os.path.dirname(me), versioneer_py)
+            )
     except NameError:
         pass
     return root
@@ -350,6 +353,7 @@ def get_config_from_root(root):
         if parser.has_option("versioneer", name):
             return parser.get("versioneer", name)
         return None
+
     cfg = VersioneerConfig()
     cfg.VCS = VCS
     cfg.style = get(parser, "style") or ""
@@ -374,17 +378,18 @@ HANDLERS = {}
 
 def register_vcs_handler(vcs, method):  # decorator
     """Decorator to mark a method as the handler for a particular VCS."""
+
     def decorate(f):
         """Store f in HANDLERS[vcs][method]."""
         if vcs not in HANDLERS:
             HANDLERS[vcs] = {}
         HANDLERS[vcs][method] = f
         return f
+
     return decorate
 
 
-def run_command(commands, args, cwd=None, verbose=False, hide_stderr=False,
-                env=None):
+def run_command(commands, args, cwd=None, verbose=False, hide_stderr=False, env=None):
     """Call the given command(s)."""
     assert isinstance(commands, list)
     p = None
@@ -392,10 +397,13 @@ def run_command(commands, args, cwd=None, verbose=False, hide_stderr=False,
         try:
             dispcmd = str([c] + args)
             # remember shell=False, so use git.cmd on windows, not just git
-            p = subprocess.Popen([c] + args, cwd=cwd, env=env,
-                                 stdout=subprocess.PIPE,
-                                 stderr=(subprocess.PIPE if hide_stderr
-                                         else None))
+            p = subprocess.Popen(
+                [c] + args,
+                cwd=cwd,
+                env=env,
+                stdout=subprocess.PIPE,
+                stderr=(subprocess.PIPE if hide_stderr else None),
+            )
             break
         except EnvironmentError:
             e = sys.exc_info()[1]
@@ -420,7 +428,9 @@ def run_command(commands, args, cwd=None, verbose=False, hide_stderr=False,
     return stdout, p.returncode
 
 
-LONG_VERSION_PY['git'] = '''
+LONG_VERSION_PY[
+    "git"
+] = '''
 # This file helps to compute a version number in source trees obtained from
 # git-archive tarball (such as those provided by githubs download-from-tag
 # feature). Distribution tarballs (built by setup.py sdist) and build
@@ -995,7 +1005,7 @@ def git_versions_from_keywords(keywords, tag_prefix, verbose):
     # starting in git-1.8.3, tags are listed as "tag: foo-1.0" instead of
     # just "foo-1.0". If we see a "tag: " prefix, prefer those.
     TAG = "tag: "
-    tags = set([r[len(TAG):] for r in refs if r.startswith(TAG)])
+    tags = set([r[len(TAG) :] for r in refs if r.startswith(TAG)])
     if not tags:
         # Either we're using git < 1.8.3, or there really are no tags. We use
         # a heuristic: assume all version tags have a digit. The old git %d
@@ -1004,7 +1014,7 @@ def git_versions_from_keywords(keywords, tag_prefix, verbose):
         # between branches and tags. By ignoring refnames without digits, we
         # filter out many common branch names like "release" and
         # "stabilization", as well as "HEAD" and "main".
-        tags = set([r for r in refs if re.search(r'\d', r)])
+        tags = set([r for r in refs if re.search(r"\d", r)])
         if verbose:
             print("discarding '%s', no digits" % ",".join(refs - tags))
     if verbose:
@@ -1012,19 +1022,26 @@ def git_versions_from_keywords(keywords, tag_prefix, verbose):
     for ref in sorted(tags):
         # sorting will prefer e.g. "2.0" over "2.0rc1"
         if ref.startswith(tag_prefix):
-            r = ref[len(tag_prefix):]
+            r = ref[len(tag_prefix) :]
             if verbose:
                 print("picking %s" % r)
-            return {"version": r,
-                    "full-revisionid": keywords["full"].strip(),
-                    "dirty": False, "error": None,
-                    "date": date}
+            return {
+                "version": r,
+                "full-revisionid": keywords["full"].strip(),
+                "dirty": False,
+                "error": None,
+                "date": date,
+            }
     # no suitable tags, so version is "0+unknown", but full hex is still there
     if verbose:
         print("no suitable tags, using unknown + full revision id")
-    return {"version": "0+unknown",
-            "full-revisionid": keywords["full"].strip(),
-            "dirty": False, "error": "no suitable tags", "date": None}
+    return {
+        "version": "0+unknown",
+        "full-revisionid": keywords["full"].strip(),
+        "dirty": False,
+        "error": "no suitable tags",
+        "date": None,
+    }
 
 
 @register_vcs_handler("git", "pieces_from_vcs")
@@ -1039,8 +1056,7 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
     if sys.platform == "win32":
         GITS = ["git.cmd", "git.exe"]
 
-    out, rc = run_command(GITS, ["rev-parse", "--git-dir"], cwd=root,
-                          hide_stderr=True)
+    out, rc = run_command(GITS, ["rev-parse", "--git-dir"], cwd=root, hide_stderr=True)
     if rc != 0:
         if verbose:
             print("Directory %s not under git control" % root)
@@ -1048,10 +1064,19 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
 
     # if there is a tag matching tag_prefix, this yields TAG-NUM-gHEX[-dirty]
     # if there isn't one, this yields HEX[-dirty] (no NUM)
-    describe_out, rc = run_command(GITS, ["describe", "--tags", "--dirty",
-                                          "--always", "--long",
-                                          "--match", "%s*" % tag_prefix],
-                                   cwd=root)
+    describe_out, rc = run_command(
+        GITS,
+        [
+            "describe",
+            "--tags",
+            "--dirty",
+            "--always",
+            "--long",
+            "--match",
+            "%s*" % tag_prefix,
+        ],
+        cwd=root,
+    )
     # --long was added in git-1.5.5
     if describe_out is None:
         raise NotThisMethod("'git describe' failed")
@@ -1074,17 +1099,16 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
     dirty = git_describe.endswith("-dirty")
     pieces["dirty"] = dirty
     if dirty:
-        git_describe = git_describe[:git_describe.rindex("-dirty")]
+        git_describe = git_describe[: git_describe.rindex("-dirty")]
 
     # now we have TAG-NUM-gHEX or HEX
 
     if "-" in git_describe:
         # TAG-NUM-gHEX
-        mo = re.search(r'^(.+)-(\d+)-g([0-9a-f]+)$', git_describe)
+        mo = re.search(r"^(.+)-(\d+)-g([0-9a-f]+)$", git_describe)
         if not mo:
             # unparseable. Maybe git-describe is misbehaving?
-            pieces["error"] = ("unable to parse git-describe output: '%s'"
-                               % describe_out)
+            pieces["error"] = "unable to parse git-describe output: '%s'" % describe_out
             return pieces
 
         # tag
@@ -1093,10 +1117,12 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
             if verbose:
                 fmt = "tag '%s' doesn't start with prefix '%s'"
                 print(fmt % (full_tag, tag_prefix))
-            pieces["error"] = ("tag '%s' doesn't start with prefix '%s'"
-                               % (full_tag, tag_prefix))
+            pieces["error"] = "tag '%s' doesn't start with prefix '%s'" % (
+                full_tag,
+                tag_prefix,
+            )
             return pieces
-        pieces["closest-tag"] = full_tag[len(tag_prefix):]
+        pieces["closest-tag"] = full_tag[len(tag_prefix) :]
 
         # distance: number of commits since tag
         pieces["distance"] = int(mo.group(2))
@@ -1107,13 +1133,13 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
     else:
         # HEX: no tags
         pieces["closest-tag"] = None
-        count_out, rc = run_command(GITS, ["rev-list", "HEAD", "--count"],
-                                    cwd=root)
+        count_out, rc = run_command(GITS, ["rev-list", "HEAD", "--count"], cwd=root)
         pieces["distance"] = int(count_out)  # total number of commits
 
     # commit date: see ISO-8601 comment in git_versions_from_keywords()
-    date = run_command(GITS, ["show", "-s", "--format=%ci", "HEAD"],
-                       cwd=root)[0].strip()
+    date = run_command(GITS, ["show", "-s", "--format=%ci", "HEAD"], cwd=root)[
+        0
+    ].strip()
     pieces["date"] = date.strip().replace(" ", "T", 1).replace(" ", "", 1)
 
     return pieces
@@ -1169,16 +1195,22 @@ def versions_from_parentdir(parentdir_prefix, root, verbose):
     for i in range(3):
         dirname = os.path.basename(root)
         if dirname.startswith(parentdir_prefix):
-            return {"version": dirname[len(parentdir_prefix):],
-                    "full-revisionid": None,
-                    "dirty": False, "error": None, "date": None}
+            return {
+                "version": dirname[len(parentdir_prefix) :],
+                "full-revisionid": None,
+                "dirty": False,
+                "error": None,
+                "date": None,
+            }
         else:
             rootdirs.append(root)
             root = os.path.dirname(root)  # up a level
 
     if verbose:
-        print("Tried directories %s but none started with prefix %s" %
-              (str(rootdirs), parentdir_prefix))
+        print(
+            "Tried directories %s but none started with prefix %s"
+            % (str(rootdirs), parentdir_prefix)
+        )
     raise NotThisMethod("rootdir doesn't start with parentdir_prefix")
 
 
@@ -1207,11 +1239,13 @@ def versions_from_file(filename):
             contents = f.read()
     except EnvironmentError:
         raise NotThisMethod("unable to read _version.py")
-    mo = re.search(r"version_json = '''\n(.*)'''  # END VERSION_JSON",
-                   contents, re.M | re.S)
+    mo = re.search(
+        r"version_json = '''\n(.*)'''  # END VERSION_JSON", contents, re.M | re.S
+    )
     if not mo:
-        mo = re.search(r"version_json = '''\r\n(.*)'''  # END VERSION_JSON",
-                       contents, re.M | re.S)
+        mo = re.search(
+            r"version_json = '''\r\n(.*)'''  # END VERSION_JSON", contents, re.M | re.S
+        )
     if not mo:
         raise NotThisMethod("no version_json in _version.py")
     return json.loads(mo.group(1))
@@ -1220,8 +1254,7 @@ def versions_from_file(filename):
 def write_to_version_file(filename, versions):
     """Write the given version number to the given _version.py file."""
     os.unlink(filename)
-    contents = json.dumps(versions, sort_keys=True,
-                          indent=1, separators=(",", ": "))
+    contents = json.dumps(versions, sort_keys=True, indent=1, separators=(",", ": "))
     with open(filename, "w") as f:
         f.write(SHORT_VERSION_PY % contents)
 
@@ -1253,8 +1286,7 @@ def render_pep440(pieces):
                 rendered += ".dirty"
     else:
         # exception #1
-        rendered = "0+untagged.%d.g%s" % (pieces["distance"],
-                                          pieces["short"])
+        rendered = "0+untagged.%d.g%s" % (pieces["distance"], pieces["short"])
         if pieces["dirty"]:
             rendered += ".dirty"
     return rendered
@@ -1368,11 +1400,13 @@ def render_git_describe_long(pieces):
 def render(pieces, style):
     """Render the given version pieces into the requested style."""
     if pieces["error"]:
-        return {"version": "unknown",
-                "full-revisionid": pieces.get("long"),
-                "dirty": None,
-                "error": pieces["error"],
-                "date": None}
+        return {
+            "version": "unknown",
+            "full-revisionid": pieces.get("long"),
+            "dirty": None,
+            "error": pieces["error"],
+            "date": None,
+        }
 
     if not style or style == "default":
         style = "pep440"  # the default
@@ -1392,9 +1426,13 @@ def render(pieces, style):
     else:
         raise ValueError("unknown style '%s'" % style)
 
-    return {"version": rendered, "full-revisionid": pieces["long"],
-            "dirty": pieces["dirty"], "error": None,
-            "date": pieces.get("date")}
+    return {
+        "version": rendered,
+        "full-revisionid": pieces["long"],
+        "dirty": pieces["dirty"],
+        "error": None,
+        "date": pieces.get("date"),
+    }
 
 
 class VersioneerBadRootError(Exception):
@@ -1417,8 +1455,9 @@ def get_versions(verbose=False):
     handlers = HANDLERS.get(cfg.VCS)
     assert handlers, "unrecognized VCS '%s'" % cfg.VCS
     verbose = verbose or cfg.verbose
-    assert cfg.versionfile_source is not None, \
-        "please set versioneer.versionfile_source"
+    assert (
+        cfg.versionfile_source is not None
+    ), "please set versioneer.versionfile_source"
     assert cfg.tag_prefix is not None, "please set versioneer.tag_prefix"
 
     versionfile_abs = os.path.join(root, cfg.versionfile_source)
@@ -1472,9 +1511,13 @@ def get_versions(verbose=False):
     if verbose:
         print("unable to compute version")
 
-    return {"version": "0+unknown", "full-revisionid": None,
-            "dirty": None, "error": "unable to compute version",
-            "date": None}
+    return {
+        "version": "0+unknown",
+        "full-revisionid": None,
+        "dirty": None,
+        "error": "unable to compute version",
+        "date": None,
+    }
 
 
 def get_version():
@@ -1523,6 +1566,7 @@ def get_cmdclass():
             print(" date: %s" % vers.get("date"))
             if vers["error"]:
                 print(" error: %s" % vers["error"])
+
     cmds["version"] = cmd_version
 
     # we override "build_py" in both distutils and setuptools
@@ -1555,14 +1599,15 @@ def get_cmdclass():
             # now locate _version.py in the new build/ directory and replace
             # it with an updated value
             if cfg.versionfile_build:
-                target_versionfile = os.path.join(self.build_lib,
-                                                  cfg.versionfile_build)
+                target_versionfile = os.path.join(self.build_lib, cfg.versionfile_build)
                 print("UPDATING %s" % target_versionfile)
                 write_to_version_file(target_versionfile, versions)
+
     cmds["build_py"] = cmd_build_py
 
     if "cx_Freeze" in sys.modules:  # cx_freeze enabled?
         from cx_Freeze.dist import build_exe as _build_exe
+
         # nczeczulin reports that py2exe won't like the pep440-style string
         # as FILEVERSION, but it can be used for PRODUCTVERSION, e.g.
         # setup(console=[{
@@ -1583,17 +1628,21 @@ def get_cmdclass():
                 os.unlink(target_versionfile)
                 with open(cfg.versionfile_source, "w") as f:
                     LONG = LONG_VERSION_PY[cfg.VCS]
-                    f.write(LONG %
-                            {"DOLLAR": "$",
-                             "STYLE": cfg.style,
-                             "TAG_PREFIX": cfg.tag_prefix,
-                             "PARENTDIR_PREFIX": cfg.parentdir_prefix,
-                             "VERSIONFILE_SOURCE": cfg.versionfile_source,
-                             })
+                    f.write(
+                        LONG
+                        % {
+                            "DOLLAR": "$",
+                            "STYLE": cfg.style,
+                            "TAG_PREFIX": cfg.tag_prefix,
+                            "PARENTDIR_PREFIX": cfg.parentdir_prefix,
+                            "VERSIONFILE_SOURCE": cfg.versionfile_source,
+                        }
+                    )
+
         cmds["build_exe"] = cmd_build_exe
         del cmds["build_py"]
 
-    if 'py2exe' in sys.modules:  # py2exe enabled?
+    if "py2exe" in sys.modules:  # py2exe enabled?
         try:
             from py2exe.distutils_buildexe import py2exe as _py2exe  # py3
         except ImportError:
@@ -1612,13 +1661,17 @@ def get_cmdclass():
                 os.unlink(target_versionfile)
                 with open(cfg.versionfile_source, "w") as f:
                     LONG = LONG_VERSION_PY[cfg.VCS]
-                    f.write(LONG %
-                            {"DOLLAR": "$",
-                             "STYLE": cfg.style,
-                             "TAG_PREFIX": cfg.tag_prefix,
-                             "PARENTDIR_PREFIX": cfg.parentdir_prefix,
-                             "VERSIONFILE_SOURCE": cfg.versionfile_source,
-                             })
+                    f.write(
+                        LONG
+                        % {
+                            "DOLLAR": "$",
+                            "STYLE": cfg.style,
+                            "TAG_PREFIX": cfg.tag_prefix,
+                            "PARENTDIR_PREFIX": cfg.parentdir_prefix,
+                            "VERSIONFILE_SOURCE": cfg.versionfile_source,
+                        }
+                    )
+
         cmds["py2exe"] = cmd_py2exe
 
     # we override different "sdist" commands for both environments
@@ -1645,8 +1698,10 @@ def get_cmdclass():
             # updated value
             target_versionfile = os.path.join(base_dir, cfg.versionfile_source)
             print("UPDATING %s" % target_versionfile)
-            write_to_version_file(target_versionfile,
-                                  self._versioneer_generated_versions)
+            write_to_version_file(
+                target_versionfile, self._versioneer_generated_versions
+            )
+
     cmds["sdist"] = cmd_sdist
 
     return cmds
@@ -1701,11 +1756,13 @@ def do_setup():
     root = get_root()
     try:
         cfg = get_config_from_root(root)
-    except (EnvironmentError, configparser.NoSectionError,
-            configparser.NoOptionError) as e:
+    except (
+        EnvironmentError,
+        configparser.NoSectionError,
+        configparser.NoOptionError,
+    ) as e:
         if isinstance(e, (EnvironmentError, configparser.NoSectionError)):
-            print("Adding sample versioneer config to setup.cfg",
-                  file=sys.stderr)
+            print("Adding sample versioneer config to setup.cfg", file=sys.stderr)
             with open(os.path.join(root, "setup.cfg"), "a") as f:
                 f.write(SAMPLE_CONFIG)
         print(CONFIG_ERROR, file=sys.stderr)
@@ -1714,15 +1771,18 @@ def do_setup():
     print(" creating %s" % cfg.versionfile_source)
     with open(cfg.versionfile_source, "w") as f:
         LONG = LONG_VERSION_PY[cfg.VCS]
-        f.write(LONG % {"DOLLAR": "$",
-                        "STYLE": cfg.style,
-                        "TAG_PREFIX": cfg.tag_prefix,
-                        "PARENTDIR_PREFIX": cfg.parentdir_prefix,
-                        "VERSIONFILE_SOURCE": cfg.versionfile_source,
-                        })
+        f.write(
+            LONG
+            % {
+                "DOLLAR": "$",
+                "STYLE": cfg.style,
+                "TAG_PREFIX": cfg.tag_prefix,
+                "PARENTDIR_PREFIX": cfg.parentdir_prefix,
+                "VERSIONFILE_SOURCE": cfg.versionfile_source,
+            }
+        )
 
-    ipy = os.path.join(os.path.dirname(cfg.versionfile_source),
-                       "__init__.py")
+    ipy = os.path.join(os.path.dirname(cfg.versionfile_source), "__init__.py")
     if os.path.exists(ipy):
         try:
             with open(ipy, "r") as f:
@@ -1764,8 +1824,10 @@ def do_setup():
     else:
         print(" 'versioneer.py' already in MANIFEST.in")
     if cfg.versionfile_source not in simple_includes:
-        print(" appending versionfile_source ('%s') to MANIFEST.in" %
-              cfg.versionfile_source)
+        print(
+            " appending versionfile_source ('%s') to MANIFEST.in"
+            % cfg.versionfile_source
+        )
         with open(manifest_in, "a") as f:
             f.write("include %s\n" % cfg.versionfile_source)
     else:


### PR DESCRIPTION
### What does this PR change?

It adds support for RemoteSLURMCluster which spins up dask-workers through the SLURM REST API instead of through subprocess.Popen.

### Why is this useful?

In environments where the python process doesn't have direct access to the SLURM CLI (f.e. a docker container) we still want to be able to use dask-jobqueue to interface with SLURM.

### Open questions

1. I've been able to write some minimal end-to-end test. The implementation largely inherits from SLURMCluster, which is sufficiently tested. Where could we invest more in tests?
2. I've not been able to test this with a workin SLURM REST API cluster, since I am still waiting on my colleagues to activate it. I'm opening this PR early to receive early reviews.

Thank you for allowing me to contribute 🙇‍♂️  @jacobtomlinson @guillaumeeb 

Resolve #502