### PR TITLE
Fix FutureWarning format_bytes/parse_bytes

### DIFF
--- a/dask_jobqueue/core.py
+++ b/dask_jobqueue/core.py
@@ -11,11 +11,13 @@ import abc
 
 import dask
 
+from dask.utils import format_bytes, parse_bytes
+
 from distributed.core import Status
 from distributed.deploy.spec import ProcessInterface, SpecCluster
 from distributed.deploy.local import nprocesses_nthreads
 from distributed.scheduler import Scheduler
-from distributed.utils import format_bytes, parse_bytes, tmpfile
+from distributed.utils import tmpfile
 
 logger = logging.getLogger(__name__)
 

--- a/dask_jobqueue/htcondor.py
+++ b/dask_jobqueue/htcondor.py
@@ -3,7 +3,7 @@ import re
 import shlex
 
 import dask
-from distributed.utils import parse_bytes
+from dask.utils import parse_bytes
 
 from .core import JobQueueCluster, Job, job_parameters, cluster_parameters
 


### PR DESCRIPTION
This PR fixes format_bytes/parse_bytes FutureWarning: format_bytes/parse_bytes is deprecated and will be removed in a future release. Please use dask.utils.format_bytes/parse_bytes instead  (https://github.com/dask/distributed/pull/4966)