### PR TITLE
JobQueueCluster: add option to change used scheduler class

### DIFF
--- a/dask_jobqueue/core.py
+++ b/dask_jobqueue/core.py
@@ -81,6 +81,9 @@ cluster_parameters = """
         port the web dashboard should use or ``scheduler_options={'host': 'your-host'}``
         to specify the host the Dask scheduler should run on. See
         :class:`distributed.Scheduler` for more details.
+    scheduler_cls : type
+        Changes the class of the used Dask Scheduler. Defaults to  Dask's
+        :class:`distributed.Scheduler`.
 """.strip()
 
 
@@ -444,6 +447,7 @@ class JobQueueCluster(SpecCluster):
         dashboard_address=None,
         host=None,
         scheduler_options=None,
+        scheduler_cls=Scheduler,  # Use local scheduler for now
         # Options for both scheduler and workers
         interface=None,
         protocol="tcp://",
@@ -510,7 +514,7 @@ class JobQueueCluster(SpecCluster):
             scheduler_options["interface"] = interface
 
         scheduler = {
-            "cls": Scheduler,  # Use local scheduler for now
+            "cls": scheduler_cls,
             "options": scheduler_options,
         }
 


### PR DESCRIPTION
The current `JobQueueCluster` implementation does not allow to change the (effective) value of `scheduler_spec["class"]`, although the underlying `SpecCluster` does support it.

The proposed change adds the keyword argument `scheduler_cls` to the `JobQueueCluster.__init__`, with it's default set to the currently used `Scheduler` (from `distributed.scheduler`) thus retaining the original behavior.
However, it makes the very same keyword argument (`scheduler_cls`) unavailable to the `**job_kwargs`. Currently, this does not interfere with any implementation within this repository and is reasonably expected to not change in the future. If, this is still an undesired effect, one could also retrieve the value from a specific entry (e.g. "cls") in the `scheduler_options` (i.e. via `scheduler_options.pop("cls", Scheduler)`).

In our particular use case, this would enable us to properly change parts of the schedulers behavior (in particular through `worker_objective` and `check_idle_saturated`) through subclassing instead of method patching which is favorable, especially in the light of the new Cython accelerated `SchedulerState`.