### PR TITLE
use dask.utils.tmpfile as distributed.utils.tmpfile was deprecated 

### DIFF
--- a/dask_jobqueue/core.py
+++ b/dask_jobqueue/core.py
@@ -11,13 +11,12 @@ import abc
 
 import dask
 
-from dask.utils import format_bytes, parse_bytes
+from dask.utils import format_bytes, parse_bytes, tmpfile
 
 from distributed.core import Status
 from distributed.deploy.spec import ProcessInterface, SpecCluster
 from distributed.deploy.local import nprocesses_nthreads
 from distributed.scheduler import Scheduler
-from distributed.utils import tmpfile
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Fixes #528