### PR TITLE
push dask requirements to 2.23 as 2.22.0 fails tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-dask>=2.19
-distributed>=2.19
+dask>=2.23
+distributed>=2.23


### PR DESCRIPTION
fixes #530 