### PR TITLE
add functions for testing in cluster specific enviroments

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -25,7 +25,13 @@ def pytest_configure(config):
 
 
 def pytest_runtest_setup(item):
-    envnames = [mark.args[0] for mark in item.iter_markers(name="env")]
+    envnames = sum(
+        [
+            mark.args[0] if isinstance(mark.args[0], list) else [mark.args[0]]
+            for mark in item.iter_markers(name="env")
+        ],
+        [],
+    )
     if (item.config.getoption("-E") is None and envnames) or (
         item.config.getoption("-E") is not None
         and item.config.getoption("-E") not in envnames


### PR DESCRIPTION
instead of testing different scheduler classes with the same test code on a local system, actually also allow iterating through different CIs

add test for security inside ci as an example