### PR TITLE
Fix a bug in resource specification

### DIFF
--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -177,6 +177,4 @@ specified for certain steps in the processing. For example:
     stage_1 = [delayed(step_1_w_single_GPU)(i) for i in range(10)]
     stage_2 = [delayed(step_2_w_local_IO)(s2) for s2 in stage_1]
 
-    result_stage_2 = client.compute(stage_2,
-                                    resources={tuple(stage_1): {'GPU': 1},
-                                               tuple(stage_2): {'ssdGB': 100}})
+    result_stage_2 = client.compute(stage_2, resources={'GPU': 1})


### PR DESCRIPTION
Tracing the edited lines back to about 4 years ago, I believe this was a typo/error in how resources are specified. There is a related StackOverflow question here: https://stackoverflow.com/a/72581445/10693596