### PR TITLE
add `pre_exec` job parameter to allow for setup commands

### DIFF
--- a/dask_jobqueue/core.py
+++ b/dask_jobqueue/core.py
@@ -60,6 +60,10 @@ job_parameters = """
     python : str
         Python executable used to launch Dask workers.
         Defaults to the Python that is submitting these jobs
+    pre_exec : list
+        Additional commands to execute before launching the actual
+        Dask worker. For example sourcing a virtual environment,
+        loading a module, etc.
     config_name : str
         Section to use from jobqueue.yaml configuration file.
     name : str
@@ -159,6 +163,7 @@ class Job(ProcessInterface, abc.ABC):
         log_directory=None,
         shebang=None,
         python=sys.executable,
+        pre_exec=None,
         job_name=None,
         config_name=None,
     ):
@@ -268,7 +273,10 @@ class Job(ProcessInterface, abc.ABC):
         if extra is not None:
             command_args += extra
 
-        self._command_template = " ".join(map(str, command_args))
+        self._command_template = ""
+        if pre_exec is not None:
+            self._command_template += "; ".join(pre_exec) + "; "
+        self._command_template += " ".join(map(str, command_args))
 
         self.log_directory = log_directory
         if self.log_directory is not None:


### PR DESCRIPTION
This allows to specify additional commands to be run before the actual `"%(python)s -m distributed.cli.dask_worker"`-call that starts the worker. This can be used to set up/source a virtual environment (or conda, mamba, ...), load a module, or whatever setup is needed.

Example usage for a venv:
```python
pre_exec = ['cd ~/projects/dask-jobqueue/example', 'source venv/bin/activate']
cluster = HTCondorCluster(cores=1, memory="2GB", disk="4GB", log_directory = 'logs',
                          pre_exec=pre_exec, python='python3')
```