### PR TITLE
htcondor: add batch_name to match the name of the Dask worker

### DIFF
--- a/dask_jobqueue/htcondor.py
+++ b/dask_jobqueue/htcondor.py
@@ -75,6 +75,7 @@ Queue
 
         self.job_header_dict = {
             "MY.DaskWorkerName": '"htcondor--$F(MY.JobId)--"',
+            "batch_name": self.name,
             "RequestCpus": "MY.DaskWorkerCores",
             "RequestMemory": "floor(MY.DaskWorkerMemory / 1048576)",
             "RequestDisk": "floor(MY.DaskWorkerDisk / 1024)",

--- a/dask_jobqueue/tests/test_htcondor.py
+++ b/dask_jobqueue/tests/test_htcondor.py
@@ -79,10 +79,13 @@ def test_basic(loop):
             future = client.submit(lambda x: x + 1, 10)
             assert future.result(QUEUE_WAIT) == 11
 
+            condor_q = Job._call(["condor_q", "-batch"]).strip()
+
             workers = list(client.scheduler_info()["workers"].values())
             w = workers[0]
             assert w["memory_limit"] == 500 * 1024**2
             assert w["nthreads"] == 1
+            assert w.name in condor_q
 
             cluster.scale(0)
 

--- a/dask_jobqueue/tests/test_htcondor.py
+++ b/dask_jobqueue/tests/test_htcondor.py
@@ -85,7 +85,7 @@ def test_basic(loop):
             w = workers[0]
             assert w["memory_limit"] == 500 * 1024**2
             assert w["nthreads"] == 1
-            assert w.name in condor_q
+            assert w.["name"] in condor_q
 
             cluster.scale(0)
 

--- a/dask_jobqueue/tests/test_htcondor.py
+++ b/dask_jobqueue/tests/test_htcondor.py
@@ -85,7 +85,7 @@ def test_basic(loop):
             w = workers[0]
             assert w["memory_limit"] == 500 * 1024**2
             assert w["nthreads"] == 1
-            assert w.["name"] in condor_q
+            assert w["name"] in condor_q
 
             cluster.scale(0)
 

--- a/dask_jobqueue/tests/test_htcondor.py
+++ b/dask_jobqueue/tests/test_htcondor.py
@@ -38,6 +38,7 @@ def test_job_script():
         cancel_command_extra=["-forcex"],
     ) as cluster:
         job_script = cluster.job_script()
+        assert "batch_name = dummy-name" in job_script
         assert "RequestCpus = MY.DaskWorkerCores" in job_script
         assert "RequestDisk = floor(MY.DaskWorkerDisk / 1024)" in job_script
         assert "RequestMemory = floor(MY.DaskWorkerMemory / 1048576)" in job_script


### PR DESCRIPTION
This makes it easier to identify the workers in the output of `condor_q`, `condor_history`, ... for debugging.

Before, the batch name was automatically set by HTCondor to the job id (or rather ClusterId in HTCondor language):
```
OWNER   BATCH_NAME      SUBMITTED   DONE   RUN    IDLE   HOLD  TOTAL JOB_IDS
jolange ID: 21671522   8/9  09:40      _      1      _      _      1 21671522.0
```

I think the name of the Dask worker is really useful to have here:
```
OWNER   BATCH_NAME           SUBMITTED   DONE   RUN    IDLE   HOLD  TOTAL JOB_IDS
jolange HTCondorCluster-1   8/9  10:17      _      1      _      _      1 21671526.0
jolange HTCondorCluster-0   8/9  10:17      _      1      _      _      1 21671527.0
```

So if you identify a worker (e.g. with problems) with `cluster.workers` or using the dashboard, it is much easier to find the right job in the batch system.