### PR TITLE
use the stored env_extra parameter from the base class for htcondor

### DIFF
--- a/dask_jobqueue/core.py
+++ b/dask_jobqueue/core.py
@@ -245,7 +245,7 @@ class Job(ProcessInterface, abc.ABC):
 
         self.shebang = shebang
 
-        self._env_header = "\n".join(filter(None, env_extra))
+        self._env_extra = env_extra
         self.header_skip = set(header_skip)
 
         # dask-worker command line build
@@ -299,7 +299,7 @@ class Job(ProcessInterface, abc.ABC):
         pieces = {
             "shebang": self.shebang,
             "job_header": header,
-            "env_header": self._env_header,
+            "env_header": "\n".join(filter(None, self._env_extra)),
             "worker_command": self._command_template,
         }
         return self._script_template % pieces

--- a/dask_jobqueue/htcondor.py
+++ b/dask_jobqueue/htcondor.py
@@ -61,17 +61,13 @@ Queue
         else:
             self.job_extra = job_extra
 
-        env_extra = base_class_kwargs.get("env_extra", None)
-        if env_extra is None:
-            env_extra = dask.config.get(
-                "jobqueue.%s.env-extra" % self.config_name, default=[]
-            )
-
-        if env_extra is not None:
+        if self._env_extra is not None:
             # Overwrite command template: prepend commands from env_extra separated by semicolon.
             # This is special for HTCondor, because lines to execute on the worker node cannot be
             # simply added to the submit script like for other batch systems.
-            self._command_template = "; ".join(env_extra + [self._command_template])
+            self._command_template = "; ".join(
+                self._env_extra + [self._command_template]
+            )
 
         self.job_header_dict = {
             "MY.DaskWorkerName": '"htcondor--$F(MY.JobId)--"',


### PR DESCRIPTION
While working on #323, I realized that it would be much easier to manage the deprecation warning if the `env_extra` parameter would only be handled in one place (including the config read). Apart from that, I think it is also cleaner, and it was stored already anyway (as a joined string, though).

Anyway, I wanted to first check in this separate PR if you see any reason not to do this, instead of hiding this change in the renaming+deprecation.