### PR TITLE
Adding HTCondor docker image build to periodic CI

### DIFF
--- a/.github/workflows/build-docker-images.yaml
+++ b/.github/workflows/build-docker-images.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        jobqueue: ["pbs", "sge", "slurm"]
+        jobqueue: ["pbs", "sge", "slurm", "htcondor"]
 
     steps:
       - name: Checkout


### PR DESCRIPTION
Fixes #540.

But we'll need to merge this PR to check things. 