### PR TITLE
Change project to account where appropriate. Update docs

### DIFF
--- a/dask_jobqueue/core.py
+++ b/dask_jobqueue/core.py
@@ -285,7 +285,7 @@ class Job(ProcessInterface, abc.ABC):
         if header_skip is not None:
             warn = (
                 "header_skip has been renamed to job_directives_skip. "
-                "You are still using it (even if only set to (); please also check config files). "
+                "You are still using it (even if only set to []; please also check config files). "
                 "If you did not set job_directives_skip yet, header_skip will be respected for now, "
                 "but it will be removed in a future release. "
                 "If you already set job_directives_skip, header_skip is ignored and you can remove it."

--- a/dask_jobqueue/jobqueue.yaml
+++ b/dask_jobqueue/jobqueue.yaml
@@ -48,7 +48,7 @@ jobqueue:
     # PBS resource manager options
     shebang: "#!/usr/bin/env bash"
     queue: null
-    project: null
+    account: null
     walltime: '00:30:00'
     env-extra: null
     job-script-prologue: []
@@ -110,7 +110,7 @@ jobqueue:
     # SLURM resource manager options
     shebang: "#!/usr/bin/env bash"
     queue: null
-    project: null
+    account: null
     walltime: '00:30:00'
     env-extra: null
     job-script-prologue: []
@@ -142,7 +142,7 @@ jobqueue:
     # PBS resource manager options
     shebang: "#!/usr/bin/env bash"
     queue: null
-    project: null
+    account: null
     walltime: '00:30:00'
     env-extra: null
     job-script-prologue: []

--- a/dask_jobqueue/lsf.py
+++ b/dask_jobqueue/lsf.py
@@ -185,7 +185,7 @@ class LSFCluster(JobQueueCluster):
     queue : str
         Destination queue for each worker job. Passed to `#BSUB -q` option.
     project : str
-        Accounting string associated with each worker job. Passed to
+        Project associated with each worker job. Passed to
         `#BSUB -P` option.
     {job}
     ncpus : int

--- a/dask_jobqueue/oar.py
+++ b/dask_jobqueue/oar.py
@@ -112,7 +112,7 @@ class OARCluster(JobQueueCluster):
     queue : str
         Destination queue for each worker job. Passed to `#OAR -q` option.
     project : str
-        Accounting string associated with each worker job. Passed to `#OAR -p` option.
+        Project associated with each worker job. Passed to `#OAR --project` option.
     {job}
     {cluster}
     resource_spec : str

--- a/dask_jobqueue/sge.py
+++ b/dask_jobqueue/sge.py
@@ -84,7 +84,7 @@ class SGECluster(JobQueueCluster):
     queue : str
         Destination queue for each worker job. Passed to `#$ -q` option.
     project : str
-        Accounting string associated with each worker job. Passed to `#$ -A` option.
+        Project associated with each worker job. Passed to `#$ -P` option.
     {job}
     {cluster}
     resource_spec : str

--- a/docs/source/configuration-setup.rst
+++ b/docs/source/configuration-setup.rst
@@ -100,19 +100,20 @@ based on their size and urgency.
 If you are unfamiliar with using queues on your system you should leave this
 blank, or ask your IT administrator.
 
-Project
--------
+Project or Account
+------------------
 
 You may have an allocation on your HPC system that is referenced by a
-*project*.  This is typically a short bit of text that references your group or
+*project* or *account*.  This is typically a short bit of text that references your group or
 a particular project.  This is typically given to you by your IT administrator
 when they give you an allocation of hours on the HPC system.
 
 .. code-block:: yaml
 
    project: XYZW-1234
+   #account: XYZW-1234
 
-If this sounds foreign to you or if you don't use project codes then you should
+If this sounds foreign to you or if you don't use project or account codes then you should
 leave this blank, or ask your IT administrator.
 
 

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -24,7 +24,7 @@ define a single job:
         # Job scheduler specific keywords
         resource_spec='select=1:ncpus=24:mem=100GB',
         queue='regular',
-        project='my-project',
+        account='my-account',
         walltime='02:00:00',
    )
 
@@ -68,7 +68,7 @@ recommend using a configuration file like the following:
 
        resource-spec: "select=1:ncpus=24:mem=100GB"
        queue: regular
-       project: my-project
+       account: my-account
        walltime: 00:30:00
 
 See :doc:`Configuration Examples <configurations>` for real-world examples.

--- a/docs/source/configurations.rst
+++ b/docs/source/configurations.rst
@@ -50,7 +50,7 @@ Geyser/Caldera).
 
        interface: ib0
 
-       project: PXYZ123
+       account: PXYZ123
        walltime: '00:30:00'
        job-extra: {-C geyser}
 
@@ -107,7 +107,7 @@ ARM Stratus
         interface: ib0
         local-directory: $localscratch
         queue: high_mem # Can also select batch or gpu_ssd
-        project: arm
+        account: arm
         walltime: 00:30:00 #Adjust this to job size
         job-extra: ['-W group_list=cades-arm']
         
@@ -134,7 +134,7 @@ Also, note that port 8787 is open both on login and computing nodes, so you can 
 
        # SLURM resource manager options
        queue: compute
-       # project: xxxxxxx # choose project other than default
+       # account: xxxxxxx # choose account other than default
        walltime: '00:30:00'
        job-mem: 120GB              # Max memory that can be requested to SLURM
 
@@ -175,7 +175,7 @@ about this ``dask-jobqueue`` config.
 
        # PBS resource manager options
        queue: mpi_1
-       project: myPROJ
+       account: myAccount
        walltime: '48:00:00'
        resource-spec: select=1:ncpus=28:mem=120GB
        # disable email

--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -14,7 +14,7 @@ PBS Deployments
    from dask_jobqueue import PBSCluster
 
    cluster = PBSCluster(queue='regular',
-                        project='DaskOnPBS',
+                        account='DaskOnPBS',
                         local_directory='$TMPDIR',
                         cores=24,
                         processes=6,
@@ -25,7 +25,7 @@ PBS Deployments
                         processes=6,
                         shebang='#!/usr/bin/env zsh',
                         memory="6GB",
-                        project='P48500028',
+                        account='P48500028',
                         queue='premium',
                         resource_spec='select=1:ncpus=36:mem=109G',
                         walltime='02:00:00',
@@ -45,7 +45,7 @@ can be used, called ``MoabCluster``:
    cluster = MoabCluster(
        cores=6,
        processes=6,
-       project="gfdl_m",
+       account="gfdl_m",
        memory="16G",
        resource_spec="pmem=96G",
        job_extra_directives=["-d /home/First.Last", "-M none"],
@@ -112,7 +112,7 @@ SLURM Deployments
    cluster = SLURMCluster(cores=8,
                           processes=4,
                           memory="16GB",
-                          project="woodshole",
+                          account="woodshole",
                           walltime="01:00:00",
                           queue="normal")
 
@@ -130,7 +130,7 @@ SLURM Deployment: Low-priority node usage
         cores=24,
         processes=6,
         memory="16GB",
-        project="co_laika",
+        account="co_laika",
         queue="savio2_bigmem",
         job_script_prologue=[
             'export LANG="en_US.utf8"',

--- a/docs/source/howitworks.rst
+++ b/docs/source/howitworks.rst
@@ -19,7 +19,7 @@ object is instantiated:
         local_directory='$TMPDIR',
         resource_spec='select=1:ncpus=24:mem=100GB',
         queue='regular',
-        project='my-project',
+        account='my-account',
         walltime='02:00:00',
    )
 


### PR DESCRIPTION
Fixes #272.

Currently dask-jobqueue uses incorrect terms and kwarg name for Accounting string. PBS and Slurm implementations are declaring an accounting string, but the kwarg was named `project`. This PR renames the kwarg to `account`, as project should be use with `-P` PBS or Slurm option.

It also fixes wrong comment about `project` kwarg for other job schedulers.