### PR TITLE
Asynchronous job submission and removal

### DIFF
--- a/dask_jobqueue/core.py
+++ b/dask_jobqueue/core.py
@@ -744,7 +744,6 @@ or by setting this value in the config file found in `~/.config/dask/jobqueue.ya
         for key, value in worker_security_dict.items():
             # dump worker in-memory keys for use in job_script
             if value is not None and "\n" in value:
-
                 try:
                     f = tempfile.NamedTemporaryFile(
                         mode="wt",

--- a/dask_jobqueue/local.py
+++ b/dask_jobqueue/local.py
@@ -71,7 +71,7 @@ class LocalJob(Job):
         return str(self.process.pid)
 
     @classmethod
-    def _close_job(self, job_id, cancel_command):
+    async def _close_job(self, job_id, cancel_command):
         os.kill(int(job_id), 9)
         # from distributed.utils_test import terminate_process
         # terminate_process(self.process)

--- a/dask_jobqueue/oar.py
+++ b/dask_jobqueue/oar.py
@@ -11,7 +11,6 @@ logger = logging.getLogger(__name__)
 
 
 class OARJob(Job):
-
     # Override class variables
     submit_command = "oarsub"
     cancel_command = "oardel"

--- a/dask_jobqueue/tests/test_htcondor.py
+++ b/dask_jobqueue/tests/test_htcondor.py
@@ -106,7 +106,6 @@ def test_extra_args_broken_cancel(loop):
         cancel_command_extra=["-name", "wrong.docker"],
     ) as cluster:
         with Client(cluster) as client:
-
             cluster.scale(2)
 
             client.wait_for_workers(2, timeout=QUEUE_WAIT)

--- a/dask_jobqueue/tests/test_jobqueue_core.py
+++ b/dask_jobqueue/tests/test_jobqueue_core.py
@@ -244,7 +244,6 @@ def get_interface_and_port(index=0):
 
 
 def test_scheduler_options(Cluster):
-
     interface, port = get_interface_and_port()
 
     with Cluster(
@@ -321,7 +320,6 @@ def test_import_scheduler_options_from_config(Cluster):
     with dask.config.set(
         {"jobqueue.%s.scheduler-options" % default_config_name: scheduler_options}
     ):
-
         with Cluster(cores=2, memory="2GB") as cluster:
             scheduler_options = cluster.scheduler_spec["options"]
             assert scheduler_options.get("interface") == config_scheduler_interface

--- a/dask_jobqueue/tests/test_lsf.py
+++ b/dask_jobqueue/tests/test_lsf.py
@@ -17,7 +17,6 @@ from . import QUEUE_WAIT
 
 def test_header():
     with LSFCluster(walltime="00:02", processes=4, cores=8, memory="8GB") as cluster:
-
         assert "#BSUB" in cluster.job_header
         assert "#BSUB -J dask-worker" in cluster.job_header
         assert "#BSUB -n 8" in cluster.job_header
@@ -35,7 +34,6 @@ def test_header():
         ncpus=24,
         mem=100000000000,
     ) as cluster:
-
         assert "#BSUB -q general" in cluster.job_header
         assert "#BSUB -J dask-worker" in cluster.job_header
         assert "#BSUB -n 24" in cluster.job_header
@@ -54,7 +52,6 @@ def test_header():
         ncpus=24,
         mem=100000000000,
     ) as cluster:
-
         assert "#BSUB -q general" in cluster.job_header
         assert "#BSUB -J dask-worker" in cluster.job_header
         assert "#BSUB -n 24" in cluster.job_header
@@ -65,7 +62,6 @@ def test_header():
         assert '#BSUB -P "Dask On LSF"' in cluster.job_header
 
     with LSFCluster(cores=4, memory="8GB") as cluster:
-
         assert "#BSUB -n" in cluster.job_header
         assert "#BSUB -W" in cluster.job_header
         assert "#BSUB -M" in cluster.job_header
@@ -75,7 +71,6 @@ def test_header():
     with LSFCluster(
         cores=4, memory="8GB", job_extra_directives=["-u email@domain.com"]
     ) as cluster:
-
         assert "#BSUB -u email@domain.com" in cluster.job_header
         assert "#BSUB -n" in cluster.job_header
         assert "#BSUB -W" in cluster.job_header
@@ -86,7 +81,6 @@ def test_header():
 
 def test_job_script():
     with LSFCluster(walltime="00:02", processes=4, cores=8, memory="28GB") as cluster:
-
         job_script = cluster.job_script()
         assert "#BSUB" in job_script
         assert "#BSUB -J dask-worker" in job_script
@@ -114,7 +108,6 @@ def test_job_script():
         ncpus=24,
         mem=100000000000,
     ) as cluster:
-
         job_script = cluster.job_script()
         assert "#BSUB -q general" in cluster.job_header
         assert "#BSUB -J dask-worker" in cluster.job_header
@@ -141,7 +134,6 @@ def test_job_script():
         project="Dask On LSF",
         job_extra_directives=["-R rusage[mem=16GB]"],
     ) as cluster:
-
         job_script = cluster.job_script()
 
         assert "#BSUB -J dask-worker" in cluster.job_header

--- a/dask_jobqueue/tests/test_pbs.py
+++ b/dask_jobqueue/tests/test_pbs.py
@@ -18,7 +18,6 @@ def test_header(Cluster):
     with Cluster(
         walltime="00:02:00", processes=4, cores=8, memory="28GB", name="dask-worker"
     ) as cluster:
-
         assert "#PBS" in cluster.job_header
         assert "#PBS -N dask-worker" in cluster.job_header
         assert "#PBS -l select=1:ncpus=8:mem=27GB" in cluster.job_header
@@ -34,7 +33,6 @@ def test_header(Cluster):
         resource_spec="select=1:ncpus=24:mem=100GB",
         memory="28GB",
     ) as cluster:
-
         assert "#PBS -q regular" in cluster.job_header
         assert "#PBS -N dask-worker" in cluster.job_header
         assert "#PBS -l select=1:ncpus=24:mem=100GB" in cluster.job_header
@@ -43,7 +41,6 @@ def test_header(Cluster):
         assert "#PBS -A DaskOnPBS" in cluster.job_header
 
     with Cluster(cores=4, memory="8GB") as cluster:
-
         assert "#PBS -j oe" not in cluster.job_header
         assert "#PBS -N" in cluster.job_header
         assert "#PBS -l walltime=" in cluster.job_header
@@ -51,7 +48,6 @@ def test_header(Cluster):
         assert "#PBS -q" not in cluster.job_header
 
     with Cluster(cores=4, memory="8GB", job_extra_directives=["-j oe"]) as cluster:
-
         assert "#PBS -j oe" in cluster.job_header
         assert "#PBS -N" in cluster.job_header
         assert "#PBS -l walltime=" in cluster.job_header
@@ -62,7 +58,6 @@ def test_header(Cluster):
 @pytest.mark.parametrize("Cluster", [PBSCluster, MoabCluster])
 def test_job_script(Cluster):
     with Cluster(walltime="00:02:00", processes=4, cores=8, memory="28GB") as cluster:
-
         job_script = cluster.job_script()
         assert "#PBS" in job_script
         assert "#PBS -N dask-worker" in job_script
@@ -88,7 +83,6 @@ def test_job_script(Cluster):
         resource_spec="select=1:ncpus=24:mem=100GB",
         memory="28GB",
     ) as cluster:
-
         job_script = cluster.job_script()
         assert "#PBS -q regular" in job_script
         assert "#PBS -N dask-worker" in job_script
@@ -119,7 +113,6 @@ def test_basic(loop):
         loop=loop,
     ) as cluster:
         with Client(cluster) as client:
-
             cluster.scale(2)
             client.wait_for_workers(2, timeout=QUEUE_WAIT)
 
@@ -154,7 +147,6 @@ def test_scale_cores_memory(loop):
         loop=loop,
     ) as cluster:
         with Client(cluster) as client:
-
             cluster.scale(cores=2)
             client.wait_for_workers(1, timeout=QUEUE_WAIT)
 
@@ -188,7 +180,6 @@ def test_basic_scale_edge_cases(loop):
         job_extra_directives=["-V"],
         loop=loop,
     ) as cluster:
-
         cluster.scale(2)
         cluster.scale(0)
 
@@ -299,7 +290,6 @@ def test_scale_grouped(loop):
         loop=loop,
     ) as cluster:
         with Client(cluster) as client:
-
             cluster.scale(4)  # Start 2 jobs
 
             start = time()

--- a/dask_jobqueue/tests/test_sge.py
+++ b/dask_jobqueue/tests/test_sge.py
@@ -16,7 +16,6 @@ def test_basic(loop):
         walltime="00:02:00", cores=8, processes=4, memory="2GiB", loop=loop
     ) as cluster:
         with Client(cluster, loop=loop) as client:
-
             cluster.scale(2)
 
             start = time()

--- a/dask_jobqueue/tests/test_slurm.py
+++ b/dask_jobqueue/tests/test_slurm.py
@@ -16,7 +16,6 @@ def test_header():
     with SLURMCluster(
         walltime="00:02:00", processes=4, cores=8, memory="28GB"
     ) as cluster:
-
         assert "#SBATCH" in cluster.job_header
         assert "#SBATCH -J dask-worker" in cluster.job_header
         assert "#SBATCH -n 1" in cluster.job_header
@@ -35,7 +34,6 @@ def test_header():
         job_cpu=16,
         job_mem="100G",
     ) as cluster:
-
         assert "#SBATCH --cpus-per-task=16" in cluster.job_header
         assert "#SBATCH --cpus-per-task=8" not in cluster.job_header
         assert "#SBATCH --mem=100G" in cluster.job_header
@@ -44,7 +42,6 @@ def test_header():
         assert "#SBATCH -p regular" in cluster.job_header
 
     with SLURMCluster(cores=4, memory="8GB") as cluster:
-
         assert "#SBATCH" in cluster.job_header
         assert "#SBATCH -J " in cluster.job_header
         assert "#SBATCH -n 1" in cluster.job_header
@@ -57,7 +54,6 @@ def test_job_script():
     with SLURMCluster(
         walltime="00:02:00", processes=4, cores=8, memory="28GB"
     ) as cluster:
-
         job_script = cluster.job_script()
         assert "#SBATCH" in job_script
         assert "#SBATCH -J dask-worker" in job_script
@@ -127,7 +123,6 @@ def test_basic(loop):
         loop=loop,
     ) as cluster:
         with Client(cluster) as client:
-
             cluster.scale(2)
 
             start = time()


### PR DESCRIPTION
This solution is using asyncio.create_subprocess_exec and similar to what was done in PR #473.
However, this other PR lacked an update job removal, which is included here.

The `test_jobqueue_job_call` required an overhaul to make it compatible with the async code. Its form is basically the same as the other async tests now.

In issue #470 another solution using `run_in_executor` was proposed. I consider the solution with `create_subprocess_exec` more rigorous though, because with `create_subprocess_exec` the code is fully using the async API, instead of wrapping non-async functionality in a `run_in_executor` call.