### PR TITLE
Slurm uses '#SBATCH -A' to set account/project name

### DIFF
--- a/dask_jobqueue/slurm.py
+++ b/dask_jobqueue/slurm.py
@@ -141,7 +141,7 @@ class SLURMCluster(JobQueueCluster):
     project : str
         Deprecated: use ``account`` instead. This parameter will be removed in a future version.
     account : str
-        Accounting string associated with each worker job. Passed to `#PBS -A` option.
+        Accounting string associated with each worker job. Passed to `#SBATCH -A` option.
     {job}
     {cluster}
     walltime : str


### PR DESCRIPTION
This fixes what probably is a copy-and-paste error form the PBS version of this file.