### PR TITLE
Update release number to 0.8.5

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -4,7 +4,7 @@ Changelog
 Development version
 -------------------
 
-0.8.3 / 2024-02-22
+0.8.5 / 2024-02-22
 ------------------
 
 - Make cli worker parameter flexible (:pr:`606`)


### PR DESCRIPTION
Due to mistake in Pypi upload of previous version.