### PR TITLE
Remove distutils dependency and unused lsf_version

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -70,21 +70,6 @@ def pytest_runtest_setup(item):
             item.add_marker(pytest.mark.xfail(reason=xfail[env]))
 
 
-@pytest.fixture(autouse=True)
-def mock_lsf_version(monkeypatch, request):
-    # Monkey-patch lsf_version() UNLESS the 'lsf' environment is selected.
-    # In that case, the real lsf_version() function should work.
-    markers = list(request.node.iter_markers())
-    if any("lsf" in marker.args for marker in markers):
-        return
-
-    try:
-        dask_jobqueue.lsf.lsf_version()
-    except OSError:
-        # Provide a fake implementation of lsf_version()
-        monkeypatch.setattr(dask_jobqueue.lsf, "lsf_version", lambda: "10")
-
-
 all_envs = {
     None: LocalCluster,
     "pbs": PBSCluster,

--- a/dask_jobqueue/lsf.py
+++ b/dask_jobqueue/lsf.py
@@ -1,5 +1,3 @@
-from distutils.version import LooseVersion
-
 import logging
 import math
 import os
@@ -240,9 +238,3 @@ class LSFCluster(JobQueueCluster):
     )
     job_cls = LSFJob
 
-
-@toolz.memoize
-def lsf_version():
-    out, _ = subprocess.Popen("lsid", stdout=subprocess.PIPE).communicate()
-    version = re.search(r"(\d+\.)+\d+", out.decode()).group()
-    return LooseVersion(version)


### PR DESCRIPTION
Fix https://github.com/dask/dask-jobqueue/issues/644.

I think `lsf_version` was used at one point but not anymore.