### PR TITLE
Handle outdated root certificates

### DIFF
--- a/ci/sge/Dockerfile
+++ b/ci/sge/Dockerfile
@@ -3,8 +3,7 @@ FROM ubuntu:14.04 as base
 ENV LANG C.UTF-8
 
 RUN apt-get update && apt-get install curl bzip2 git gcc -y --fix-missing
-
-RUN curl -o miniconda.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh && \
+RUN curl -ko miniconda.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh && \
     bash miniconda.sh -f -b -p /opt/anaconda && \
     /opt/anaconda/bin/conda clean -tipy && \
     rm -f miniconda.sh


### PR DESCRIPTION
The current SGE image is based on `ubuntu:14.04` as it is a similar age to the last SGE release. The root ca certificates have expired which is causing the miniconda download to fail. This PR tells `curl` to ignore the expired certificates.

In an ideal world we update the container to a more modern OS, but given the age of the SGE packages this feels like a large undertaking.