### PR TITLE
Bump minimum Python to 3.9

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,6 +40,7 @@ jobs:
       - name: Setup Job queuing system
         if: matrix.jobqueue != 'none'
         run: |
+          cp ci/environment.yml ci/${{ matrix.jobqueue }}/environment.yml
           source ci/${{ matrix.jobqueue }}.sh
           jobqueue_before_install
 

--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - python=3.8
+  - python=3.9
   - dask
   - distributed
   - flake8

--- a/ci/htcondor.sh
+++ b/ci/htcondor.sh
@@ -6,7 +6,7 @@ function jobqueue_before_install {
 
     # start htcondor cluster
     cd ./ci/htcondor
-    docker compose pull
+    docker compose build
     ./start-htcondor.sh
     docker compose exec -T submit /bin/bash -c "condor_status"
     docker compose exec -T submit /bin/bash -c "condor_q"

--- a/ci/pbs.sh
+++ b/ci/pbs.sh
@@ -6,7 +6,7 @@ function jobqueue_before_install {
 
     # start pbs cluster
     cd ./ci/pbs
-    docker compose pull
+    docker compose build
     ./start-pbs.sh
     cd -
 

--- a/ci/sge.sh
+++ b/ci/sge.sh
@@ -6,7 +6,7 @@ function jobqueue_before_install {
 
     # start sge cluster
     cd ./ci/sge
-    docker compose pull
+    docker compose build
     ./start-sge.sh
     cd -
 

--- a/ci/sge/docker-compose.yml
+++ b/ci/sge/docker-compose.yml
@@ -42,7 +42,7 @@ services:
       context: .
       target: slave
       args:
-        PYTHON_VERSION: 3.8
+        PYTHON_VERSION: 3.9
     container_name: slave_two
     hostname: slave_two
     #network_mode: host

--- a/ci/slurm.sh
+++ b/ci/slurm.sh
@@ -6,7 +6,7 @@ function jobqueue_before_install {
 
     # start slurm cluster
     cd ./ci/slurm
-    docker compose pull
+    docker compose build
     ./start-slurm.sh
     cd -
 

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     cmdclass=versioneer.get_cmdclass(),
     description="Deploy Dask on job queuing systems like PBS, Slurm, SGE or LSF",
     url="https://jobqueue.dask.org",
-    python_requires=">=3.8",
+    python_requires=">=3.9",
     license="BSD 3-Clause",
     packages=["dask_jobqueue"],
     include_package_data=True,


### PR DESCRIPTION
Dask dropped 3.8 support in https://github.com/dask/community/issues/315. This PR makes 3.9 the minimum version here.