### PR TITLE
Replace pytest-asyncio with anyio

### DIFF
--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -9,5 +9,5 @@ dependencies:
   - flake8
   - black
   - pytest
-  - pytest-asyncio
+  - anyio
   - cryptography

--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -9,5 +9,6 @@ dependencies:
   - flake8
   - black
   - pytest
+  - pytest-asyncio
   - anyio
   - cryptography

--- a/conftest.py
+++ b/conftest.py
@@ -26,6 +26,11 @@ from dask_jobqueue.local import LocalCluster
 import warnings
 
 
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
 def pytest_addoption(parser):
     parser.addoption(
         "-E",

--- a/dask_jobqueue/tests/test_job.py
+++ b/dask_jobqueue/tests/test_job.py
@@ -21,7 +21,7 @@ def test_basic(Cluster):
     assert "127.0.0.1:12345" in job.job_script()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_job(EnvSpecificCluster):
     job_cls = EnvSpecificCluster.job_cls
     async with Scheduler(port=0) as s:
@@ -39,7 +39,7 @@ async def test_job(EnvSpecificCluster):
             assert time() < start + 10
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_cluster(EnvSpecificCluster):
     job_cls = EnvSpecificCluster.job_cls
     async with JobQueueCluster(
@@ -62,7 +62,7 @@ async def test_cluster(EnvSpecificCluster):
                 assert time() < start + 10
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_adapt(EnvSpecificCluster):
     job_cls = EnvSpecificCluster.job_cls
     async with JobQueueCluster(
@@ -92,7 +92,7 @@ async def test_adapt(EnvSpecificCluster):
             assert not cluster.workers
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_adapt_parameters(EnvSpecificCluster):
     job_cls = EnvSpecificCluster.job_cls
     async with JobQueueCluster(
@@ -205,7 +205,7 @@ def test_deprecation_header_skip(Cluster):
     assert "jobname" not in job_script
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_nworkers_scale():
     async with LocalCluster(
         cores=2, memory="4GB", processes=2, asynchronous=True
@@ -432,7 +432,7 @@ def test_deprecation_job_extra(Cluster):
     assert "old_param" in job_script
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_jobqueue_job_call(tmpdir, Cluster):
     async with Cluster(cores=1, memory="1GB", asynchronous=True) as cluster:
         path = tmpdir.join("test.py")

--- a/dask_jobqueue/tests/test_jobqueue_core.py
+++ b/dask_jobqueue/tests/test_jobqueue_core.py
@@ -184,7 +184,7 @@ def test_cluster_has_cores_and_memory(Cluster):
         Cluster(cores=4)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_config_interface():
     net_if_addrs = psutil.net_if_addrs()
     interface = list(net_if_addrs.keys())[0]

--- a/dask_jobqueue/tests/test_pbs.py
+++ b/dask_jobqueue/tests/test_pbs.py
@@ -378,7 +378,7 @@ def test_informative_errors():
     assert "cores" in str(info.value)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_adapt(loop):
     async with PBSCluster(cores=1, memory="1 GB", asynchronous=True) as cluster:
         cluster.adapt()

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ extras_require = {}
 
 extras_require["test"] = [
     "pytest",
-    "pytest-asyncio",
+    "anyio",
     "cryptography",
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ extras_require = {}
 
 extras_require["test"] = [
     "pytest",
+    "pytest-asyncio",
     "anyio",
     "cryptography",
 ]


### PR DESCRIPTION
In other Dask projects we've found that `pytest-asyncio` causes a bunch of headaches. The test tooling from `anyio` is much more reliable.

This PR replaces `pytest-asyncio` with `anyio` as a test dependency. It configures `anyio` to only use the `asyncio` backend for testing and replaces the pytest marks where needed.