### PR TITLE
Enable GitHub Actions build concurrency groups

### DIFF
--- a/.github/workflows/build-docker-images.yaml
+++ b/.github/workflows/build-docker-images.yaml
@@ -8,6 +8,10 @@ on:
     - cron: "0 0 * * *" # Daily “At 00:00”
   workflow_dispatch: # allows you to trigger manually
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,6 +2,10 @@ name: CI
 
 on: [push, pull_request]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -15,10 +19,6 @@ jobs:
         jobqueue: ["htcondor", "pbs", "sge", "slurm", "none"]
 
     steps:
-      - name: Cancel previous runs
-        uses: styfle/cancel-workflow-action@0.7.0
-        with:
-            access_token: ${{ github.token }}
       - name: Checkout source
         uses: actions/checkout@v2
 


### PR DESCRIPTION
Replace the `styfle/cancel-workflow-action` action with GitHub Actions concurrency groups. This is the modern way to cancel running workflows if a new commit is pushed to a PR.