### PR TITLE
Remove gitter badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 Deploy Dask on Job Queueing systems
 ===================================
 
-|Build Status| |Doc Status| |Gitter| |Version Status|
+|Build Status| |Doc Status| |Version Status|
 
 Easy deployment of Dask Distributed on job queuing systems such as PBS, Slurm,
 or SGE.  See documentation_ for more information.
@@ -18,8 +18,5 @@ New BSD. See `License File <https://github.com/dask/dask-jobqueue/blob/main/LICE
 .. |Doc Status| image:: https://readthedocs.org/projects/dask-jobqueue/badge/?version=latest
    :target: https://jobqueue.dask.org/en/latest/
    :alt: Documentation Status
-.. |Gitter| image:: https://badges.gitter.im/Join%20Chat.svg
-   :alt: Join the chat at https://gitter.im/dask/dask
-   :target: https://gitter.im/dask/dask?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge
 .. |Version Status| image:: https://img.shields.io/pypi/v/dask-jobqueue.svg
    :target: https://pypi.python.org/pypi/dask-jobqueue/


### PR DESCRIPTION
We don't use gitter any more so removing badge from README.