### PR TITLE
Add pre-commit linting to CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -63,10 +63,6 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-        with:
-          python-version: "3.10"
-      - name: Install deps
-        run: ./ci/install-deps.sh
-      - uses: pre-commit/action@v2.0.0
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v3
+      - uses: pre-commit/action@v3.0.1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,3 +59,14 @@ jobs:
         run: |
           source ci/${{ matrix.jobqueue }}.sh
           jobqueue_after_script
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: "3.10"
+      - name: Install deps
+        run: ./ci/install-deps.sh
+      - uses: pre-commit/action@v2.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,11 @@
 repos:
 -   repo: https://github.com/psf/black
-    rev: 24.2.0
+    rev: 24.8.0
     hooks:
     - id: black
       language_version: python3
 -   repo: https://github.com/pycqa/flake8
-    rev: 7.0.0
+    rev: 7.1.1
     hooks:
     - id: flake8
       types: [file, python]

--- a/ci/none.sh
+++ b/ci/none.sh
@@ -10,8 +10,6 @@ function jobqueue_install {
 }
 
 function jobqueue_script {
-  flake8 -j auto dask_jobqueue
-  black --exclude versioneer.py --check .
   pytest --verbose
 }
 


### PR DESCRIPTION
This PR moves `black` and `flake8` out of `ci/none.sh` and runs `pre-commit` in GitHub Actions instead. This gives a more consistent linting experience between local development and CI.

I also took the opportunity to run `pre-commit autoupdate` to bump to the latest versions of `black` and `flake8`.