### PR TITLE
Bump minimum Python to 3.10

### DIFF
--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - python=3.9
+  - python=3.10
   - dask
   - distributed
   - flake8

--- a/ci/sge/docker-compose.yml
+++ b/ci/sge/docker-compose.yml
@@ -41,8 +41,6 @@ services:
     build:
       context: .
       target: slave
-      args:
-        PYTHON_VERSION: 3.9
     container_name: slave_two
     hostname: slave_two
     #network_mode: host

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     cmdclass=versioneer.get_cmdclass(),
     description="Deploy Dask on job queuing systems like PBS, Slurm, SGE or LSF",
     url="https://jobqueue.dask.org",
-    python_requires=">=3.9",
+    python_requires=">=3.10",
     license="BSD 3-Clause",
     packages=["dask_jobqueue"],
     include_package_data=True,


### PR DESCRIPTION
Dask dropped Python 3.9 in 2024.8.1 in line with NEP29. This PR bumps CI here to 3.10 and removes 3.9 support.