### PR TITLE
Use GitHub Actions for PyPI publish on release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,26 @@
+name: Publish to PyPI
+on:
+  push:
+    tags:
+      - "*.*.*"
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    if: github.repository == 'dask/dask-jobqueue'
+    environment:
+      name: pypi
+      url: https://pypi.org/p/dask-jobqueue
+    permissions:
+      id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v1
+        with:
+          python-version: "3.10"
+      - name: Build package
+        run: pip install build && pyproject-build
+      - name: Publish kr8s
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,5 +22,5 @@ jobs:
           python-version: "3.10"
       - name: Build package
         run: pip install build && pyproject-build
-      - name: Publish kr8s
+      - name: Publish
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/docs/release-procedure.md
+++ b/docs/release-procedure.md
@@ -21,13 +21,7 @@ git tag -a x.x.x -m 'Version x.x.x'
 git push --tags upstream
 ````
 
-* Build the wheel/dist and upload to PyPI:
-
-````
-git clean -xfd
-python setup.py sdist bdist_wheel --universal
-twine upload dist/*
-````
+* A [GitHub Actions workflow](../.github/workflows/release.yaml) will build the wheel/dist and upload to PyPI
 
 * The Conda Forge bots should pick up the change automatically within an hour
 or two. Then follow the instructions from the automatic e-mail that you will


### PR DESCRIPTION
Adds a GitHub Actions workflow that builds new tags and pushes them to PyPI. This removes a little bit of potential human error when it comes to building the distributions.

The new release process will be:
- Update the Changelog
- Create a new tag on main
- Push the tag to the upstream repo
- Wait for bots to do their thing