### PR TITLE
Remove Anaconda defaults channel

### DIFF
--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -1,6 +1,7 @@
 name: dask-jobqueue
 channels:
   - conda-forge
+  - nodefaults
 dependencies:
   - python=3.10
   - dask

--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -1,7 +1,6 @@
 name: dask-jobqueue
 channels:
   - conda-forge
-  - defaults
 dependencies:
   - python=3.10
   - dask


### PR DESCRIPTION
It's unclear whether the recent news around using the Anaconda `defaults` channel is problematic for Dask projects. But maybe it's best to remove `defaults` just in case.