### PR TITLE
Only add signal handler on main thread

### DIFF
--- a/dask_jobqueue/runner.py
+++ b/dask_jobqueue/runner.py
@@ -16,6 +16,8 @@ from distributed.worker import Worker
 
 
 # Close gracefully when receiving a SIGINT
+# We use SIGINT to shut down because the scheduler and worker hang
+# if we call sys.exit() see https://github.com/dask/distributed/issues/8644
 if threading.current_thread() is threading.main_thread():
     signal.signal(signal.SIGINT, lambda *_: sys.exit())
 

--- a/dask_jobqueue/runner.py
+++ b/dask_jobqueue/runner.py
@@ -4,6 +4,7 @@ import os
 import signal
 from contextlib import suppress
 from enum import Enum
+import threading
 from typing import Dict, Optional
 import warnings
 from tornado.ioloop import IOLoop
@@ -15,7 +16,8 @@ from distributed.worker import Worker
 
 
 # Close gracefully when receiving a SIGINT
-signal.signal(signal.SIGINT, lambda *_: sys.exit())
+if threading.current_thread() is threading.main_thread():
+    signal.signal(signal.SIGINT, lambda *_: sys.exit())
 
 
 class Role(Enum):


### PR DESCRIPTION
The new runners added in #659 use signal handlers to shut down. This is because the Dask distributed scheduler and worker hang when we call `sys.exit()` https://github.com/dask/distributed/issues/8644.

We only need to add these handlers if you're using the runners, and its probably safe to assume that the runners will only be used from the main thread. So this PR adds a check that skips adding the handler if we are in a child thread.

Closes #667 