### PR TITLE
Set -N=1/--nodes=1 for SLURM workers

### DIFF
--- a/dask_jobqueue/slurm.py
+++ b/dask_jobqueue/slurm.py
@@ -81,9 +81,10 @@ class SLURMJob(Job):
         if account is not None:
             header_lines.append("#SBATCH -A %s" % account)
 
-        # Init resources, always 1 task,
+        # Init resources, always 1 task, 1 node,
         # and then number of cpu is processes * threads if not set
         header_lines.append("#SBATCH -n 1")
+        header_lines.append("#SBATCH -N 1")
         header_lines.append(
             "#SBATCH --cpus-per-task=%d" % (job_cpu or self.worker_cores)
         )

--- a/dask_jobqueue/tests/test_slurm.py
+++ b/dask_jobqueue/tests/test_slurm.py
@@ -35,6 +35,7 @@ def test_header():
         assert "#SBATCH" in cluster.job_header
         assert "#SBATCH -J dask-worker" in cluster.job_header
         assert "#SBATCH -n 1" in cluster.job_header
+        assert "#SBATCH -N 1" in cluster.job_header
         assert "#SBATCH --cpus-per-task=8" in cluster.job_header
         assert "#SBATCH --mem=27G" in cluster.job_header
         assert "#SBATCH -t 00:02:00" in cluster.job_header
@@ -61,6 +62,7 @@ def test_header():
         assert "#SBATCH" in cluster.job_header
         assert "#SBATCH -J " in cluster.job_header
         assert "#SBATCH -n 1" in cluster.job_header
+        assert "#SBATCH -N 1" in cluster.job_header
         assert "#SBATCH -t " in cluster.job_header
         assert "#SBATCH -p" not in cluster.job_header
         # assert "#SBATCH -A" not in cluster.job_header
@@ -76,6 +78,7 @@ def test_job_script():
         formatted_bytes = format_bytes(parse_bytes("7GB")).replace(" ", "")
         assert f"--memory-limit {formatted_bytes}" in job_script
         assert "#SBATCH -n 1" in job_script
+        assert "#SBATCH -N 1" in cluster.job_header
         assert "#SBATCH --cpus-per-task=8" in job_script
         assert "#SBATCH --mem=27G" in job_script
         assert "#SBATCH -t 00:02:00" in job_script
@@ -108,6 +111,7 @@ def test_job_script():
         assert "#SBATCH" in job_script
         assert "#SBATCH -J dask-worker" in job_script
         assert "#SBATCH -n 1" in job_script
+        assert "#SBATCH -N 1" in cluster.job_header
         assert "#SBATCH --cpus-per-task=8" in job_script
         assert "#SBATCH --mem=27G" in job_script
         assert "#SBATCH -t 00:02:00" in job_script


### PR DESCRIPTION
The SLURM worker hardcodes --ntasks=1/-n=1, but on the SLURM cluster that I have experience with (SDSC Expanse), you also have to set -N=1/--nodes=1.