### PR TITLE
Update .gitignore to follow Python.gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,9 +3,6 @@ __pycache__/
 *.py[cod]
 *$py.class
 
-# C extensions
-*.so
-
 # Distribution / packaging
 .Python
 build/

--- a/.gitignore
+++ b/.gitignore
@@ -1,25 +1,142 @@
-*.pyc
-*.egg-info
-docs/_build
-docs/build
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
 build/
+develop-eggs/
 dist/
-.idea/
-log.*
-log
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+*.manifest
+*.spec
+
+# Installer logs
+distutils.log
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
 .coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+docs/build/
+
+# PyBuilder
+.target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+# Pipfile.lock
+
+# poetry
+# poetry.lock
+
+# pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+.dmypy-working/
+
+# Editor and IDE settings
+.idea/
+.vscode/
+
+# OS and swap files
 .DS_Store
 *.swp
 *.swo
-.cache/
-.pytest_cache
-docs/source/generated
+
+# Certificate and key files
+ca.pem
+key.pem
+*.out
+
+# Project-specific files
 dask-worker-space/
 ci/slurm/environment.yml
 ci/pbs/environment.yml
 ci/sge/environment.yml
 ci/htcondor/environment.yml
-.vscode/
-ca.pem
-key.pem
-*.out


### PR DESCRIPTION
Just a small PR that updates `.gitignore` to match the latest [Python.gitignore](https://github.com/github/gitignore/blob/main/Python.gitignore).

I ran into issues where setting up my environment with `.venv` caused lots of files to appear in git that should have been ignored.

If you notice any project-specific ignores missing, just let me know!
