### PR TITLE
Expose `queue` Attribute on Cluster Objects

### DIFF
--- a/dask_jobqueue/core.py
+++ b/dask_jobqueue/core.py
@@ -575,6 +575,7 @@ class JobQueueCluster(SpecCluster):
         protocol=None,
         # Job keywords
         config_name=None,
+        queue=None,  # <-- Add queue parameter
         **job_kwargs
     ):
         self.status = Status.created
@@ -662,6 +663,10 @@ class JobQueueCluster(SpecCluster):
         job_kwargs["interface"] = interface
         job_kwargs["protocol"] = protocol
         job_kwargs["security"] = self._get_worker_security(security)
+        
+        self.queue = queue
+        if queue is not None:
+            job_kwargs["queue"] = queue
 
         self._job_kwargs = job_kwargs
 


### PR DESCRIPTION
I often manage several Dask clusters at once, each using a different queue name. Currently there is no easy way to check which queue a cluster is using after it is created. I have to use `.job_script()` and a regex to extract the queue name from the generated script `re.search(r"#PBS -q (\S+)", cluster.job_script())`. 

I think it would be nice to have direct access to the queue name from the cluster object itself. With this PR, you can simply use `cluster.queue` to retrieve the queue name.

Example:
```python
cluster = PBSCluster(cores=1, memory="1GB", queue="test")  # Any object that inherits from JobQueueCluster
print(cluster.queue)  # "test"
```