### PR TITLE
Only set signal handler in runners

### DIFF
--- a/dask_jobqueue/runner.py
+++ b/dask_jobqueue/runner.py
@@ -15,14 +15,6 @@ from distributed.utils import LoopRunner, import_term, SyncMethodMixin
 from distributed.worker import Worker
 
 
-def setup_signal_handler():
-    # Close gracefully when receiving a SIGINT
-    # We use SIGINT to shut down because the scheduler and worker hang
-    # if we call sys.exit() see https://github.com/dask/distributed/issues/8644
-    if threading.current_thread() is threading.main_thread():
-        signal.signal(signal.SIGINT, lambda *_: sys.exit())
-
-
 class Role(Enum):
     """
     This Enum contains the various roles processes can be.
@@ -69,7 +61,11 @@ class BaseRunner(SyncMethodMixin):
         asynchronous: bool = False,
         loop: asyncio.BaseEventLoop = None,
     ):
-        setup_signal_handler()
+        # Close gracefully when receiving a SIGINT
+        # We use SIGINT to shut down because the scheduler and worker hang
+        # if we call sys.exit() see https://github.com/dask/distributed/issues/8644
+        if threading.current_thread() is threading.main_thread():
+            signal.signal(signal.SIGINT, lambda *_: sys.exit())
         self.status = Status.created
         self.scheduler = scheduler
         self.scheduler_address = None


### PR DESCRIPTION
Closes #696 

We only want to override the signal handler if the user is using a runner. Runners should take full control of managing process lifecycle. However, currently the signal handler is configured on import which applied when using standard cluster managers.

This PR moves signal handler setup to the runner initialization.