### PR TITLE
Remove duplicate interactive redirect entry

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -57,7 +57,6 @@ redirects = {
     "howitworks": "clusters-howitworks.html",
     "api": "clusters-api.html",
     "configuration-setup": "clusters-configuration-setup.html",
-    "interactive": "clusters-interactive.html",
     "configurations": "clusters-configuration-examples.html",
     "examples": "clusters-example-deployments.html",
 }


### PR DESCRIPTION
## Summary

This PR removes the duplicate `"interactive"` key from the `redirects` dictionary in `docs/source/conf.py`.

## Changes

- Removed the duplicate `"interactive"` redirect entry.
- `ruff check .` now passes without the F601 duplicate dictionary key warning.

## Verification

- [x] `ruff check .` passes.